### PR TITLE
Add contributor names to apachesolr document. (Untested)

### DIFF
--- a/openscholar/modules/os_features/os_publications/os_publications.module
+++ b/openscholar/modules/os_features/os_publications/os_publications.module
@@ -1358,7 +1358,13 @@ function os_publications_revert_citeproc_style($name, $path = '') {
 function os_publications_apachesolr_index_document_build_node(ApacheSolrDocument $doc, $entity, $env_id) {
   if ($entity->type == 'biblio') {
     foreach ($entity->biblio_contributors as $c) {
-      $doc->addField('contributors', $c['name']);
+      $doc->addField('sm_contributors', $c['name']);
     }
   }
+}
+
+function os_publications_apachesolr_query_alter($query) {
+  $params['qf']['sm_contributors'] = 'sm_contributors^1.0';
+  $query->addParams($params);
+  drush_print_r($query);
 }

--- a/openscholar/modules/os_features/os_publications/os_publications.module
+++ b/openscholar/modules/os_features/os_publications/os_publications.module
@@ -1358,13 +1358,12 @@ function os_publications_revert_citeproc_style($name, $path = '') {
 function os_publications_apachesolr_index_document_build_node(ApacheSolrDocument $doc, $entity, $env_id) {
   if ($entity->type == 'biblio') {
     foreach ($entity->biblio_contributors as $c) {
-      $doc->addField('sm_contributors', $c['name']);
+      $doc->addField('tm_contributors', $c['name']);
     }
   }
 }
 
 function os_publications_apachesolr_query_alter($query) {
-  $params['qf']['sm_contributors'] = 'sm_contributors^1.0';
+  $params['qf']['tm_contributors'] = 'tm_contributors^30';
   $query->addParams($params);
-  drush_print_r($query);
 }

--- a/openscholar/modules/os_features/os_publications/os_publications.module
+++ b/openscholar/modules/os_features/os_publications/os_publications.module
@@ -1351,3 +1351,14 @@ function os_publications_revert_citeproc_style($name, $path = '') {
 
   return true;
 }
+
+/**
+ * Adds full author names to index
+ */
+function os_publications_apachesolr_index_document_build_node(ApacheSolrDocument $doc, $entity, $env_id) {
+  if ($entity->type == 'biblio') {
+    foreach ($entity->biblio_contributors as $c) {
+      $doc->addField('contributors', $c['name']);
+    }
+  }
+}


### PR DESCRIPTION
From #6837.

I think this is done but haven't tested it at all.

I didn't want to install/configure apachesolr to test this locally, so I was hoping to use travis to do it. Just waiting on #6763 to be done so I can set them up.