### PR TITLE
Fix term not being applied when applying term in the content page.

### DIFF
--- a/openscholar/modules/cp/modules/cp_content/cp_content.module
+++ b/openscholar/modules/cp/modules/cp_content/cp_content.module
@@ -338,7 +338,7 @@ function cp_content_assign_taxonomy_action(&$node, $context) {
   $applied_titles = array();
   $wrapper = entity_metadata_wrapper('node', $node);
   // Check if the bundle of the node is associated with selected vocabulary.
-  if (!in_array($node->type, $bundle_names)) {
+  if (in_array($node->type, $bundle_names)) {
     // Assign the term(s) to the current node.
     $node_terms = $wrapper->{OG_VOCAB_FIELD}->value(array('identifier' => TRUE));
     $node_terms = array_merge($node_terms ,$selected_terms);

--- a/openscholar/modules/cp/modules/cp_content/cp_content.module
+++ b/openscholar/modules/cp/modules/cp_content/cp_content.module
@@ -447,10 +447,10 @@ function cp_content_remove_taxonomy_action(&$node, $context) {
 
       $params = array(
         '%terms' => implode(", ", $names),
-        '%node' => $removed_title['title'],
+        '!node' => $removed_title['title'],
       );
 
-      $message = format_plural(count($removed_title['removed_terms']), 'Taxonomy term %terms was removed from the content: %node', '@count taxonomy terms %terms were removed from the content: %node', $params);
+      $message = format_plural(count($removed_title['removed_terms']), 'Taxonomy term %terms was removed from the content: !node', '@count taxonomy terms %terms were removed from the content: %node', $params);
       drupal_set_message($message);
     }
   }

--- a/openscholar/modules/cp/modules/cp_content/cp_content.module
+++ b/openscholar/modules/cp/modules/cp_content/cp_content.module
@@ -450,7 +450,7 @@ function cp_content_remove_taxonomy_action(&$node, $context) {
         '!node' => $removed_title['title'],
       );
 
-      $message = format_plural(count($removed_title['removed_terms']), 'Taxonomy term %terms was removed from the content: !node', '@count taxonomy terms %terms were removed from the content: %node', $params);
+      $message = format_plural(count($removed_title['removed_terms']), 'Taxonomy term %terms was removed from the content: !node', '@count taxonomy terms %terms were removed from the content: !node', $params);
       drupal_set_message($message);
     }
   }


### PR DESCRIPTION
#6945 

Before the fix the term wasn't applied as the condition for applying the term was wrong. So before we got this error:
![selection_999 412](https://cloud.githubusercontent.com/assets/4497748/6163787/edf07cbc-b2d1-11e4-991f-63ce4f2384c1.png)

And after the fix:
![selection_999 411](https://cloud.githubusercontent.com/assets/4497748/6163790/fb74cdf2-b2d1-11e4-94da-09af12122a5f.png)

The vocabulary that was used is indeed applicable to the "biblio" content type.
