### PR TITLE
Don't allow saving a vocabulary with machine name that has commas.

### DIFF
--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -58,6 +58,7 @@ function _os_importer_import_behalf_of_user(FeedsSource $source, $entity, $item,
  */
 function _os_importer_import_vocab(FeedsSource $source, $entity, $item, $id) {
   $config = $source->importer->getConfig();
+  $pattern = '/[^a-zA-Z0-9]/';
 
   // Getting the mappings from the processor config.
   $mappings = array();
@@ -74,8 +75,7 @@ function _os_importer_import_vocab(FeedsSource $source, $entity, $item, $id) {
     // Create the terms and the vocabulary.
     if (preg_match('@[^a-z0-9_]+@', $vocab)) {
       $params['@name'] = $vocab;
-      $vocab = str_replace(array(' ', '.', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')'), '', strtolower($vocab));
-      $vocab = str_replace(array('_', '-'), '_', $vocab);
+      $vocab = preg_replace($pattern, '', strtolower($vocab));
       $params['@new-name'] = $vocab;
       drupal_set_message(t("The vocab name @name contained not allowed characters. The vocab name is @new-name. You can change vocabulary's name in the future.", $params), 'notice');
     }

--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -78,7 +78,7 @@ function _os_importer_import_vocab(FeedsSource $source, $entity, $item, $id) {
       $vocab = preg_replace($pattern, '', strtolower($vocab));
       $params['@new-name'] = $vocab;
       $params['@taxonomy-page'] = url('cp/build/build/taxonomy');
-      $text = "The vocabulary name \"@name\" contains not allowed character(s), it has been changed to \"@new-name\".";
+      $text = "The vocabulary name \"@name\" contains disallowed character(s), it has been changed to \"@new-name\".";
       $text .= "All special characters and spaces are removed from the original name during importing.";
       $text .= "You can change the vocabulary name in <a href='@taxonomy-page'>cp/build/build/taxonomy</a> in the future.";
       drupal_set_message(t($text, $params), 'notice');

--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -77,7 +77,11 @@ function _os_importer_import_vocab(FeedsSource $source, $entity, $item, $id) {
       $params['@name'] = $vocab;
       $vocab = preg_replace($pattern, '', strtolower($vocab));
       $params['@new-name'] = $vocab;
-      drupal_set_message(t("The vocab name @name contained not allowed characters. The vocab name is @new-name. You can change vocabulary's name in the future.", $params), 'notice');
+      $params['@taxonomy-page'] = url('cp/build/build/taxonomy');
+      $text = "The vocabulary name \"@name\" contains not allowed character(s), it has been changed to \"@new-name\".";
+      $text .= "All special characters and spaces are removed from the original name during importing.";
+      $text .= "You can change the vocabulary name in <a href='@taxonomy-page'>cp/build/build/taxonomy</a> in the future.";
+      drupal_set_message(t($text, $params), 'notice');
     }
     $info = _os_importer_create_vocab($vocab, $item[$original_name], 'node', $id, 'node', $entity->type);
 

--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -132,7 +132,7 @@ function _os_importer_create_vocab($name, $terms, $group_type, $gid, $entity_typ
   else {
     // We didn't found any vocabulary - create a new one.
     $i = 0;
-    $machine_name = str_replace(array(' ', '-', ','), '_', strtolower($name));
+    $machine_name = str_replace(array(' ', '-', ','), array('_', '_', ''), strtolower($name));
     while (taxonomy_vocabulary_machine_name_load($machine_name)) {
       $machine_name = substr($machine_name, 0, 32 - strlen($i)) . $i;
       $i++;

--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -58,7 +58,7 @@ function _os_importer_import_behalf_of_user(FeedsSource $source, $entity, $item,
  */
 function _os_importer_import_vocab(FeedsSource $source, $entity, $item, $id) {
   $config = $source->importer->getConfig();
-  $pattern = '/[^a-zA-Z0-9]/';
+  $pattern = '/[^a-zA-Z0-9_]/';
 
   // Getting the mappings from the processor config.
   $mappings = array();

--- a/openscholar/modules/os/modules/os_importer/os_importer.api.inc
+++ b/openscholar/modules/os/modules/os_importer/os_importer.api.inc
@@ -132,7 +132,7 @@ function _os_importer_create_vocab($name, $terms, $group_type, $gid, $entity_typ
   else {
     // We didn't found any vocabulary - create a new one.
     $i = 0;
-    $machine_name = str_replace(array(' ', '-'), '_', strtolower($name));
+    $machine_name = str_replace(array(' ', '-', ','), '_', strtolower($name));
     while (taxonomy_vocabulary_machine_name_load($machine_name)) {
       $machine_name = substr($machine_name, 0, 32 - strlen($i)) . $i;
       $i++;

--- a/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.install
+++ b/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.install
@@ -65,3 +65,10 @@ function vsite_vocab_update_7002(&$sandbox) {
     'entity' => 'taxonomy_vocabulary',
   ));
 }
+
+/**
+ * Remove comma characters from the vocabulary machine name.
+ */
+function vsite_vocab_update_7003(&$sandbox) {
+  vsite_vocab_update_7002($sandbox);
+}

--- a/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
+++ b/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
@@ -542,7 +542,7 @@ function _vsite_vocab_update_query($id = NULL) {
  */
 function _vsite_vocab_name_fix_iterator($vocabulary) {
   $name = $vocabulary->machine_name;
-  $pattern = '/[^a-zA-Z0-9]/';
+  $pattern = '/[^a-zA-Z0-9_]/';
 
   if (!preg_match('@[^a-z0-9_]+@', $name)) {
     // The vocabulary name is OK. Return.

--- a/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
+++ b/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
@@ -554,7 +554,7 @@ function _vsite_vocab_name_fix_iterator($vocabulary) {
   ));
 
   // Fix the name.
-  $name = str_replace(array(' ', '.'), '', strtolower($name));
+  $name = str_replace(array(' ', '.', ','), '', strtolower($name));
 
   if (taxonomy_vocabulary_machine_name_load($name)) {
     // Create unique name.

--- a/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
+++ b/openscholar/modules/vsite/modules/vsite_vocab/vsite_vocab.module
@@ -542,6 +542,7 @@ function _vsite_vocab_update_query($id = NULL) {
  */
 function _vsite_vocab_name_fix_iterator($vocabulary) {
   $name = $vocabulary->machine_name;
+  $pattern = '/[^a-zA-Z0-9]/';
 
   if (!preg_match('@[^a-z0-9_]+@', $name)) {
     // The vocabulary name is OK. Return.
@@ -554,7 +555,7 @@ function _vsite_vocab_name_fix_iterator($vocabulary) {
   ));
 
   // Fix the name.
-  $name = str_replace(array(' ', '.', ','), '', strtolower($name));
+  $name = preg_replace($pattern, '', strtolower($name));
 
   if (taxonomy_vocabulary_machine_name_load($name)) {
     // Create unique name.


### PR DESCRIPTION
#6947 

This PR changes the ``,`` characters in the machine name of the vocab before saving it. Before this change, the imported vocabulary was saved with a machine name that contained a comma. 
Using the ``cp/build/taxonomy/add`` to add a vocab with a comma works fine and strips the comma:
![selection_999 415](https://cloud.githubusercontent.com/assets/4497748/6164457/61dfa898-b2da-11e4-8c85-2dd74f38eb05.png)




