### PR TITLE
Fix capitalization of Publication words.

### DIFF
--- a/openscholar/modules/os_features/os_publications/os_publications.install
+++ b/openscholar/modules/os_features/os_publications/os_publications.install
@@ -1300,3 +1300,14 @@ function os_publications_update_7028(){
   return t('Removed inline indents from biblio_citeproc citations.');
 }
 
+/**
+ * Update stored Chicago-author-date style definition to match updated file.
+ */
+function os_publications_update_7029() {
+  $messages = array();
+  if (os_publications_revert_citeproc_style('chicago-author-date')) {
+    $messages[] = t('Chicago Author Date style reverted.');
+  }
+
+  return implode('<br />', $messages);
+}

--- a/temporary/biblio/modules/CiteProc/CSL.inc
+++ b/temporary/biblio/modules/CiteProc/CSL.inc
@@ -302,7 +302,21 @@ class csl_format extends csl_rendering_element {
           break;
         case 'capitalize-all':
         case 'title':
-          $text = mb_convert_case($text, MB_CASE_TITLE);
+          // If this is not a link we want to avoid capitalizing certain words.
+          if (strpos($text, '<a') == FALSE) {
+            // Words to skip.
+            $except = array('of');
+            $parts = explode(' ', $text);
+            foreach ($parts as $key => $part) {
+              if (!in_array($part, $except)) {
+                $parts[$key] = drupal_ucfirst($part);
+              }
+            }
+            $text = implode(' ', $parts);
+          }
+          else {
+            $text = ucwords($text);
+          }
           break;
         case 'capitalize-first':
           $text = drupal_ucfirst($text);

--- a/temporary/biblio/modules/CiteProc/CSL.inc
+++ b/temporary/biblio/modules/CiteProc/CSL.inc
@@ -302,7 +302,7 @@ class csl_format extends csl_rendering_element {
           break;
         case 'capitalize-all':
         case 'title':
-          $text = ucwords($text);
+          $text = mb_convert_case($text, MB_CASE_TITLE);
           break;
         case 'capitalize-first':
           $text = drupal_ucfirst($text);

--- a/temporary/biblio/modules/CiteProc/CSL.inc
+++ b/temporary/biblio/modules/CiteProc/CSL.inc
@@ -302,21 +302,7 @@ class csl_format extends csl_rendering_element {
           break;
         case 'capitalize-all':
         case 'title':
-          // If this is not a link we want to avoid capitalizing certain words.
-          if (strpos($text, '<a') == FALSE) {
-            // Words to skip.
-            $except = array('of');
-            $parts = explode(' ', $text);
-            foreach ($parts as $key => $part) {
-              if (!in_array($part, $except)) {
-                $parts[$key] = drupal_ucfirst($part);
-              }
-            }
-            $text = implode(' ', $parts);
-          }
-          else {
-            $text = ucwords($text);
-          }
+          $text = ucwords($text);
           break;
         case 'capitalize-first':
           $text = drupal_ucfirst($text);

--- a/temporary/biblio/modules/CiteProc/style/chicago-author-date.csl
+++ b/temporary/biblio/modules/CiteProc/style/chicago-author-date.csl
@@ -395,7 +395,7 @@
     </choose>
     <choose>
       <if type="legal_case" match="none">
-        <text variable="container-title" text-case="title" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
#7038 

This PR deals with the capitalization of words in the biblio entries. The original issue is dealing with the Chicago manual of style but I couldn't isolate the use case completely so I tried to prevent affecting other case. 
Before the change we had:
![selection_999 494](https://cloud.githubusercontent.com/assets/4497748/6726968/5c613398-ce58-11e4-821c-4b805085fd65.png)

We now have:
![selection_999 492](https://cloud.githubusercontent.com/assets/4497748/6726982/7ca43dee-ce58-11e4-9cdf-d00ee6813d55.png)

