### PR TITLE
Avoid caching when displaying events in "full" display in LOP.

### DIFF
--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -240,7 +240,6 @@ class os_sv_list extends os_boxes_default {
     $page_num = pager_find_page(PagerDefault::$maxElement);
 
     $this->set_cache_id($cid, $page_num);
-
     if (($block['content'] = $this->get_cache()) === FALSE) {
       $block['content'] = NULL;
       $assets = array();

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -244,7 +244,7 @@ class os_sv_list extends os_boxes_default {
     // Check if rebuild is needed for this display.
     $defaults = $this->options_defaults();
     $display = $this->options['display'];
-    $rebuild = $defaults['rebuild']['display'][$display];
+    $rebuild = !empty($defaults['rebuild']['display'][$display]) ? $defaults['rebuild']['display'][$display] : FALSE;
 
     if (($block['content'] = $this->get_cache()) === FALSE || $rebuild) {
       $block['content'] = NULL;

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -241,12 +241,7 @@ class os_sv_list extends os_boxes_default {
 
     $this->set_cache_id($cid, $page_num);
 
-    // Check if rebuild is needed for this display.
-    $defaults = $this->options_defaults();
-    $display = $this->options['display'];
-    $rebuild = !empty($defaults['rebuild']['display'][$display]) ? $defaults['rebuild']['display'][$display] : FALSE;
-
-    if (($block['content'] = $this->get_cache()) === FALSE || $rebuild) {
+    if (($block['content'] = $this->get_cache()) === FALSE) {
       $block['content'] = NULL;
       $assets = array();
       $this->options += $this->options_defaults();
@@ -341,9 +336,7 @@ class os_sv_list extends os_boxes_default {
         $block['assets'] = $assets;
         $block['content'] = "<div id='box-${delta}-page' data-page='${page_num}' data-delta='${delta}' class='${class}'>${content}</div>${pager}{$more}";
       }
-      if (!$rebuild) {
-        $this->set_cache($block['content'], $assets);
-      }
+      $this->set_cache($block['content'], $assets);
     }
 
     return $block;

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -288,13 +288,15 @@ class os_sv_list extends os_boxes_default {
 
       // Give plugins a chance to alter the entities after loading but before
       // rendering. see events.
-      $entities = entity_load($this->entity_type, $ids);
+      // When viewing nodes we wouldn't load them from the static cache due to
+      // problems when viewing the node in the node page.
+      $entities = entity_load($this->entity_type, $ids, array(), $this->entity_type == 'node');
       $entities = array_map(function ($e) { $e->sv_list = TRUE; return $e; }, $entities);
       $this->_plugins_invoke('entities_alter', $entities);
-      
+
       // If we have entities render them out, otherwise cache (null) as the content.
       if (!empty($entities)) {
-        
+
         if ($this->options['display'] == 'title') {
           $render = $this->display_title($entities);
         }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -286,20 +286,17 @@ class os_sv_list extends os_boxes_default {
         $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
       }
 
-      // Full view modes events have different display in the page and outside
-      // the page. When rendering the box with events for the first time in the
-      // event page the cache will store one of the events as it would displayed
-      // in the page.
-      // In order to prevent it we need get a fresh copy of the entity so we
-      // could add the sv_list property and not change the node object viewed in
-      // the page and the node rendering will render the event as it was
-      // displayed in a full view mode.
-      $static_reset = $this->entity_type == 'node' && !empty($this->options['content_type']) && $this->options['content_type'] == 'event';
-
       // Give plugins a chance to alter the entities after loading but before
       // rendering. see events.
-      $entities = entity_load($this->entity_type, $ids, array(), $static_reset);
-      $entities = array_map(function ($e) { $e->sv_list = TRUE; return $e; }, $entities);
+      $entities = entity_load($this->entity_type, $ids);
+      $entities = array_map(function ($e) {
+        $new_entity = clone $e;
+        unset($new_entity->page);
+        $new_entity->sv_list = TRUE;
+
+        return $new_entity;
+      }, $entities);
+
       $this->_plugins_invoke('entities_alter', $entities);
 
       // If we have entities render them out, otherwise cache (null) as the content.

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -240,7 +240,13 @@ class os_sv_list extends os_boxes_default {
     $page_num = pager_find_page(PagerDefault::$maxElement);
 
     $this->set_cache_id($cid, $page_num);
-    if (($block['content'] = $this->get_cache()) === FALSE) {
+
+    // Check if rebuild is needed for this display.
+    $defaults = $this->options_defaults();
+    $display = $this->options['display'];
+    $rebuild = $defaults['rebuild']['display'][$display];
+
+    if (($block['content'] = $this->get_cache()) === FALSE || $rebuild) {
       $block['content'] = NULL;
       $assets = array();
       $this->options += $this->options_defaults();
@@ -335,7 +341,9 @@ class os_sv_list extends os_boxes_default {
         $block['assets'] = $assets;
         $block['content'] = "<div id='box-${delta}-page' data-page='${page_num}' data-delta='${delta}' class='${class}'>${content}</div>${pager}{$more}";
       }
-      $this->set_cache($block['content'], $assets);
+      if (!$rebuild) {
+        $this->set_cache($block['content'], $assets);
+      }
     }
 
     return $block;

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -286,11 +286,19 @@ class os_sv_list extends os_boxes_default {
         $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
       }
 
+      // Full view modes events have different display in the page and outside
+      // the page. When rendering the box with events for the first time in the
+      // event page the cache will store one of the events as it would displayed
+      // in the page.
+      // In order to prevent it we need get a fresh copy of the entity so we
+      // could add the sv_list property and not change the node object viewed in
+      // the page and the node rendering will render the event as it was
+      // displayed in a full view mode.
+      $static_reset = $this->entity_type == 'node' && !empty($this->options['content_type']) && $this->options['content_type'] == 'event';
+
       // Give plugins a chance to alter the entities after loading but before
       // rendering. see events.
-      // When viewing nodes we wouldn't load them from the static cache due to
-      // problems when viewing the node in the node page.
-      $entities = entity_load($this->entity_type, $ids, array(), $this->entity_type == 'node');
+      $entities = entity_load($this->entity_type, $ids, array(), $static_reset);
       $entities = array_map(function ($e) { $e->sv_list = TRUE; return $e; }, $entities);
       $this->_plugins_invoke('entities_alter', $entities);
 

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_node.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_node.inc
@@ -56,20 +56,4 @@ class os_sv_list_box extends os_sv_list {
   function sort_alpha(EntityFieldQuery &$efq) {
     $efq->propertyOrderBy('title', 'ASC');
   }
-
-  protected function set_cache_id($bundle = NULL, $page = NULL) {
-    // In case of an event page, we need to have a cached version of the box
-    // for each event.
-    // @TODO: we should cache by the date id and not nid. Otherwise there is a problem with repeating events.
-    if ($bundle == 'node:event') {
-      $object = menu_get_object();
-      dpm($object);
-      if ($object && $object->type == 'event'){
-        $this->cache_id = parent::set_cache_id($bundle, $page) . ':' . $object->nid;
-        return $this->cache_id;
-      }
-    }
-
-    return parent::set_cache_id($bundle, $page);
-  }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_node.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_node.inc
@@ -56,4 +56,20 @@ class os_sv_list_box extends os_sv_list {
   function sort_alpha(EntityFieldQuery &$efq) {
     $efq->propertyOrderBy('title', 'ASC');
   }
+
+  protected function set_cache_id($bundle = NULL, $page = NULL) {
+    // In case of an event page, we need to have a cached version of the box
+    // for each event.
+    // @TODO: we should cache by the date id and not nid. Otherwise there is a problem with repeating events.
+    if ($bundle == 'node:event') {
+      $object = menu_get_object();
+      dpm($object);
+      if ($object && $object->type == 'event'){
+        $this->cache_id = parent::set_cache_id($bundle, $page) . ':' . $object->nid;
+        return $this->cache_id;
+      }
+    }
+
+    return parent::set_cache_id($bundle, $page);
+  }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
@@ -13,21 +13,6 @@ $plugin = array(
 );
 
 class sv_list_node_event extends sv_list_plugin  {
-
-  /**
-   * Sets values of options in new boxes.
-   */
-  public function options_defaults() {
-    return array(
-      // Specify in which cases the list should be rebuilt.
-      'rebuild' => array(
-        'display' => array(
-          'full' => TRUE,
-        ),
-      ),
-    );
-  }
-
   /**
    * @function register_sorts()
    *

--- a/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
@@ -13,6 +13,21 @@ $plugin = array(
 );
 
 class sv_list_node_event extends sv_list_plugin  {
+
+  /**
+   * Sets values of options in new boxes.
+   */
+  public function options_defaults() {
+    return array(
+      // Specify in which cases the list should be rebuilt.
+      'rebuild' => array(
+        'display' => array(
+          'full' => TRUE,
+        ),
+      ),
+    );
+  }
+
   /**
    * @function register_sorts()
    *

--- a/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
@@ -53,15 +53,19 @@ class sv_list_node_event extends sv_list_plugin  {
     // So we need to add a value to the entities array for each row in the raw DB
     // Every entity we need should already be in the entities array
     $output = array();
-    $raw = $this->query->ordered_results;
-    // use this instead of a foreach because this query can have more results than expected
-    for ($i=0; $i<$options['number_of_items']; $i++) {
-      if ($row = $raw[$i]) {
-        $entity = clone $entities[$row->entity_id];
-        $entity->date_id = implode('.', array('date', $entity->nid, 'field_date', $row->delta));
-        $output[] = $entity;
+    $results = $this->query->ordered_results;
+
+    foreach ($results as $delta => $result) {
+      $entity = clone $entities[$result->entity_id];
+      $entity->date_id = implode('.', array('date', $entity->nid, 'field_date', $result->delta));
+      $output[] = $entity;
+
+      if ($delta >= $options['number_of_items']) {
+        continue;
       }
     }
+
+    // use this instead of a foreach because this query can have more results than expected
 
     $entities = $output;
   }

--- a/openscholar/modules/os_features/os_events/os_events.module
+++ b/openscholar/modules/os_features/os_events/os_events.module
@@ -307,7 +307,7 @@ function os_events_process_node(&$variables) {
     $register = '<span class="register-event-full">' . t('Sorry, the event is full') . '</span>';
   }
 
-  if ($variables['page']) {
+  if ($variables['page'] && empty($variables['sv_list'])) {
     // Change the date markup if this is a recurring event.
     if ($variables['content']['field_date']['#items'][0]['rrule']) {
       $variables['content']['field_date'][0]['#markup'] = _os_events_style_recurring_event($variables['content']['field_date'][0]['#markup']);

--- a/openscholar/themes/hwpi_basetheme/templates/node--event.tpl.php
+++ b/openscholar/themes/hwpi_basetheme/templates/node--event.tpl.php
@@ -115,7 +115,7 @@ hide($content['links']);
   <?php endif; ?>
 
   <div class="event-content">
-    <?php if ($title && !$page): ?>
+    <?php if ($title && (!empty($sv_list) || !$page)): ?>
       <header<?php print $header_attributes; ?>>
         <?php if ($title): ?>
           <h1<?php print $title_attributes; ?>>

--- a/openscholar/themes/os_basetheme/template.php
+++ b/openscholar/themes/os_basetheme/template.php
@@ -162,7 +162,7 @@ function os_basetheme_menu_link(array $vars) {
  */
 function os_basetheme_preprocess_node(&$vars) {
   // Event nodes, inject variables for date month and day shield
-  if ($vars['node']->type == 'event' && !$vars['page']) {
+  if ($vars['node']->type == 'event' && (!empty($vars['sv_list']) || !$vars['page'])) {
     $vars['event_start'] = array();
     $delta = 0;
     if (isset($vars['node']->date_id)) {


### PR DESCRIPTION
#7062 

This PR adds an array to default options of a plugin so we can tell the parent class, ``os_sv_list`` when not to cache the widget and build it from scratch. So now we have:
![selection_999 516](https://cloud.githubusercontent.com/assets/4497748/6844101/0ea682f2-d3e4-11e4-9c69-d7e69d4078a5.png)
![selection_999 515](https://cloud.githubusercontent.com/assets/4497748/6844102/0ea7a786-d3e4-11e4-8e6b-eda1cf2cbcaf.png)
