### PR TITLE
Make sort by sticky first in the LOP.

### DIFF
--- a/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
+++ b/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
@@ -138,16 +138,22 @@ function os_sv_list_query_sv_list_biblio_alter(&$query) {
   $query->join('biblio', 'b', 'b.nid = ogm.etid');
   $query->orderBy('b.biblio_year', 'DESC');
 
-  // Order first by the biblio year, and lastly by sticky.
-  $fields =& $query->getOrderBy();
-  if (!empty($fields['node.sticky'])) {
-    $order = $fields['node.sticky'];
-    unset($fields['node.sticky']);
-    $fields['node.sticky'] = $order;
+  // If this query is used for the sv_list plugin, keep the sticky sort as is.
+  $sv_list = $query->getMetaData('sv_list');
+  if (!$sv_list) {
+    // The query is not used for the sv_list. Order first by the biblio year,
+    // and then by sticky.
+    $fields =& $query->getOrderBy();
+    if (!empty($fields['node.sticky'])) {
+      $order = $fields['node.sticky'];
+      unset($fields['node.sticky']);
+      $fields['node.sticky'] = $order;
+    }
   }
-  //Order by biblio_date
+
+  // Order by biblio_date.
   $query->orderBy('b.biblio_date', 'DESC');
-  //Lastly order by created.
+  // Lastly order by created.
   $query->orderBy('node.created', 'DESC');
 }
 

--- a/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
+++ b/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
@@ -171,11 +171,23 @@ function os_sv_list_query_sv_list_events_alter(SelectQueryInterface $query) {
   // add the delta to the fields
   $query->fields('field_data_field_date_delta_sv_list_events', array('delta'));
 
-  // sort on the right table
-  $order = &$query->getOrderBy();
-  $order = array(
-    'field_data_field_date_delta_sv_list_events.field_date_value' => 'ASC'
-  );
+  // If this query is used for the sv_list plugin, keep the sticky sort as is.
+  $sv_list = $query->getMetaData('sv_list');
+  if ($sv_list) {
+    // Sort first by sticky and use the right table.
+    $order = &$query->getOrderBy();
+    $order = array(
+      'node.sticky' => 'DESC',
+      'field_data_field_date_delta_sv_list_events.field_date_value' => 'ASC'
+    );
+  }
+  else {
+    // Sort on the right table.
+    $order = &$query->getOrderBy();
+    $order = array(
+      'field_data_field_date_delta_sv_list_events.field_date_value' => 'ASC'
+    );
+  }
 
   // this table isn't needed anymore
   $tables = &$query->getTables();

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -611,9 +611,12 @@ class os_sv_list extends os_boxes_default {
    * priority.
    *
    * @param $query
-   *  The query object.
+   *   The query object.
    */
   private function order_by_sticky(&$query) {
+    // Make note of the fact this query is executed for the list of posts widget.
+    $query->addMetaData('sv_list', TRUE);
+
     $sticky = array(
       'type' => 'property',
       'specifier' => 'sticky',
@@ -627,7 +630,7 @@ class os_sv_list extends os_boxes_default {
       return;
     }
 
-    // Look for the sticky sort. If it is already in the query,remove it.
+    // Look for the sticky sort. If it is already in the query, remove it.
     foreach ($sorts as $k => $sort) {
       if ($sort['specifier'] == 'sticky') {
         array_splice($sorts, $k, 1);

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -372,6 +372,9 @@ class os_sv_list extends os_boxes_default {
 
     $this->_plugins_invoke('sort_alter', $query);
 
+    // Always use the sticky as the first order criterion.
+    $this->order_by_sticky($query);
+
     // Execute.
     $result = $query->execute();
     return (isset($result[$this->entity_type])) ? array_keys($result[$this->entity_type]) : array();
@@ -601,5 +604,38 @@ class os_sv_list extends os_boxes_default {
         }
         break;
     }
-  }  
+  }
+
+  /**
+   * Add the sticky sort if not already in the query and make it first
+   * priority.
+   *
+   * @param $query
+   *  The query object.
+   */
+  private function order_by_sticky(&$query) {
+    $sticky = array(
+      'type' => 'property',
+      'specifier' => 'sticky',
+      'direction' => 'DESC',
+    );
+
+    $sorts = &$query->order;
+    if (empty($sorts)) {
+      // No sort was set yet. Set it to sticky.
+      $sorts[] = $sticky;
+      return;
+    }
+
+    // Look for the sticky sort. If it is already in the query,remove it.
+    foreach ($sorts as $k => $sort) {
+      if ($sort['specifier'] == 'sticky') {
+        array_splice($sorts, $k, 1);
+        break;
+      }
+    }
+
+    // Add the sort by sticky to be the first sort.
+    array_unshift($sorts, $sticky);
+  }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -372,8 +372,10 @@ class os_sv_list extends os_boxes_default {
 
     $this->_plugins_invoke('sort_alter', $query);
 
-    // Always use the sticky as the first order criterion.
-    $this->order_by_sticky($query);
+    // Always use the sticky as the first order criterion when displaying nodes.
+    if ($query->entityConditions['entity_type']['value'] == 'node') {
+      $this->order_by_sticky($query);
+    }
 
     // Execute.
     $result = $query->execute();

--- a/openscholar/modules/os/os.install
+++ b/openscholar/modules/os/os.install
@@ -739,3 +739,14 @@ function os_update_7035() {
   $revert = array_fill_keys($apps, array('feeds_importer'));
   features_revert($revert);
 }
+
+/**
+ * Revert blog and events views to add "sticky" sort criteria.
+ */
+function os_update_7036() {
+  $revert = array(
+    'os_events' => array('views'),
+    'os_blog' => array('views'),
+  );
+  features_revert($revert);
+}

--- a/openscholar/modules/os/os.install
+++ b/openscholar/modules/os/os.install
@@ -745,8 +745,8 @@ function os_update_7035() {
  */
 function os_update_7036() {
   $revert = array(
-    'os_events' => array('views'),
-    'os_blog' => array('views'),
+    'os_events' => array('views_view'),
+    'os_blog' => array('views_view'),
   );
   features_revert($revert);
 }

--- a/openscholar/modules/os_features/os_blog/os_blog.views_default.inc
+++ b/openscholar/modules/os_features/os_blog/os_blog.views_default.inc
@@ -46,16 +46,16 @@ function os_blog_views_default_views() {
   $handler->display->display_options['fields']['title']['label'] = '';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
-  /* Sort criterion: Content: Post date */
-  $handler->display->display_options['sorts']['created']['id'] = 'created';
-  $handler->display->display_options['sorts']['created']['table'] = 'node';
-  $handler->display->display_options['sorts']['created']['field'] = 'created';
-  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
   /* Sort criterion: Content: Sticky */
   $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
   $handler->display->display_options['sorts']['sticky']['table'] = 'node';
   $handler->display->display_options['sorts']['sticky']['field'] = 'sticky';
   $handler->display->display_options['sorts']['sticky']['order'] = 'DESC';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
   /* Contextual filter: Content: Author uid */
   $handler->display->display_options['arguments']['uid']['id'] = 'uid';
   $handler->display->display_options['arguments']['uid']['table'] = 'node';

--- a/openscholar/modules/os_features/os_events/os_events.views_default.inc
+++ b/openscholar/modules/os_features/os_events/os_events.views_default.inc
@@ -69,6 +69,11 @@ function os_events_views_default_views() {
   );
   $handler->display->display_options['fields']['field_date']['group_rows'] = FALSE;
   $handler->display->display_options['fields']['field_date']['delta_offset'] = '0';
+  /* Sort criterion: Content: Sticky */
+  $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
+  $handler->display->display_options['sorts']['sticky']['table'] = 'node';
+  $handler->display->display_options['sorts']['sticky']['field'] = 'sticky';
+  $handler->display->display_options['sorts']['sticky']['order'] = 'DESC';
   /* Sort criterion: Content: Date -  start date (field_date) */
   $handler->display->display_options['sorts']['field_date_value']['id'] = 'field_date_value';
   $handler->display->display_options['sorts']['field_date_value']['table'] = 'field_data_field_date';
@@ -493,6 +498,11 @@ function os_events_views_default_views() {
   $handler->display->display_options['row_options']['links'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Content: Sticky */
+  $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
+  $handler->display->display_options['sorts']['sticky']['table'] = 'node';
+  $handler->display->display_options['sorts']['sticky']['field'] = 'sticky';
+  $handler->display->display_options['sorts']['sticky']['order'] = 'DESC';
   /* Sort criterion: Content: Date -  start date (field_date) */
   $handler->display->display_options['sorts']['field_date_value']['id'] = 'field_date_value';
   $handler->display->display_options['sorts']['field_date_value']['table'] = 'field_data_field_date';


### PR DESCRIPTION
#7066 

In this PR we add the "sticky" sort in the LOP (sv_list) right before the query is executed.