### PR TITLE
Fix Patent publication type issues.

### DIFF
--- a/openscholar/modules/os_features/os_publications/os_publications.module
+++ b/openscholar/modules/os_features/os_publications/os_publications.module
@@ -423,6 +423,8 @@ function os_publications_form_biblio_node_form_alter(&$form, &$form_state) {
         '#type' => 'hidden',
         '#value' => isset($node->biblio_edition) ? $node->biblio_edition : '',
       );
+      // Hide the unneeded second patent number.
+      unset($form['biblio_tabs'][9]['biblio_issn']);
       break;
   }
 

--- a/openscholar/modules/os_features/os_publications/os_publications.module
+++ b/openscholar/modules/os_features/os_publications/os_publications.module
@@ -825,6 +825,13 @@ function os_publications_form_biblio_node_form_field_adjust($form) {
       unset($form[$field]);
     }
   }
+
+  // In case of a patent we add weight to the biblio section. This is done here
+  // because it didn't stick when done in the form alter.
+  if ($form['biblio_type']['#value'] == 119) {
+    $form['biblio_section']['#weight'] = 1.6;
+  }
+
   return $form;
 }
 

--- a/openscholar/modules/os_features/os_publications/os_publications.theme.inc
+++ b/openscholar/modules/os_features/os_publications/os_publications.theme.inc
@@ -191,6 +191,20 @@ function _os_publications_plain_citation($node) {
 
   $citation = theme('biblio_style', array('node' => $node, 'base' => $base, 'style_name' => $style));
 
+  // Add the patent number, patent source and patent issuing country, if no
+  // present in the citation.
+  if ($node->biblio_type == 119) {
+    if (strpos($citation, ' ' . $node->biblio_section) === FALSE){
+      $citation .= ' ' . $node->biblio_section;
+    }
+    if (strpos($citation, ' ' . $node->biblio_volume) === FALSE){
+      $citation .= ' Patent: ' . $node->biblio_volume . '.';
+    }
+    if (strpos($citation, $node->biblio_issue) === FALSE){
+      $citation .= ' Patent source: ' . $node->biblio_issue . '.';
+    }
+  }
+
   $allowed_html_elements = variable_get('html_title_allowed_elements', array('em', 'sub', 'sup'));
   $citation = filter_xss($citation, $allowed_html_elements);
 

--- a/openscholar/modules/os_features/os_publications/os_publications.theme.inc
+++ b/openscholar/modules/os_features/os_publications/os_publications.theme.inc
@@ -194,13 +194,13 @@ function _os_publications_plain_citation($node) {
   // Add the patent number, patent source and patent issuing country, if no
   // present in the citation.
   if ($node->biblio_type == 119) {
-    if (strpos($citation, ' ' . $node->biblio_section) === FALSE){
+    if (!empty($node->biblio_section) && strpos($citation, ' ' . $node->biblio_section) === FALSE){
       $citation .= ' ' . $node->biblio_section;
     }
-    if (strpos($citation, ' ' . $node->biblio_volume) === FALSE){
-      $citation .= ' Patent: ' . $node->biblio_volume . '.';
+    if (!empty($node->biblio_volume) && strpos($citation, ' ' . $node->biblio_volume) === FALSE){
+      $citation .= ' Patent ' . $node->biblio_volume . '.';
     }
-    if (strpos($citation, $node->biblio_issue) === FALSE){
+    if (!empty($node->biblio_issue) && strpos($citation, $node->biblio_issue) === FALSE){
       $citation .= ' Patent source: ' . $node->biblio_issue . '.';
     }
   }


### PR DESCRIPTION
#7069 

This is still a WIP.

Now when we add the patent number, source and issuing country it displays the values in case they are missing from the citation:
![selection_999 523](https://cloud.githubusercontent.com/assets/4497748/6915513/3c772f24-d7c7-11e4-82e8-ead61d427233.png)

Output:
![selection_999 522](https://cloud.githubusercontent.com/assets/4497748/6915520/44017218-d7c7-11e4-9a76-1cb9809dcb07.png)
