### PR TITLE
Fix missing sections in Publication listing.

### DIFF
--- a/openscholar/modules/os/includes/os_infinite_scroll.js
+++ b/openscholar/modules/os/includes/os_infinite_scroll.js
@@ -49,18 +49,20 @@
                 $(settings.pager).hide();
               }
             }
-            
+
             //hide redundant biblio headers
             function os_publications_hide_biblio_category_bar() {
-              selector = '.biblio-separator-bar';            
+              selector = '.biblio-separator-bar';
               $selectors = $(selector);
-                
+
               $selectors.each(function(selectors) {
                 html = $(this).html()
-                $selectors.filter(':contains("'+html+'"):not(:first)').remove() //filter(':contains("'+html+'")').remove();
+                $selectors.filter(function() {
+                  return $(this).text() === html;
+                }).not(':first').remove();
               });
             }
-                      
+
             //prep settings
             var settings = Drupal.settings.autopager[mod]
             if (settings.loading_image) {
@@ -86,7 +88,7 @@
           }
         }
       });
-    }, 
+    }
   }
-  
+
 })(jQuery);


### PR DESCRIPTION
#7075 

This PR changes the selector for the ``.biblio-separator-bar`` we remove. The use of ``:contains()`` was wrong as the word "Journal" appears in both "Journal" and "Journal article". Same goes for "Book" and "Book chapter". It should work now:
![selection_999 549](https://cloud.githubusercontent.com/assets/4497748/7104933/d11b96e6-e132-11e4-943f-119556a807a3.png)
![selection_999 548](https://cloud.githubusercontent.com/assets/4497748/7104934/d13dfee8-e132-11e4-9230-5a9a515c1f97.png)

