### PR TITLE
Display the LOP only if user can view the displayed content.

### DIFF
--- a/openscholar/behat/features/bootstrap/FeatureContext.php
+++ b/openscholar/behat/features/bootstrap/FeatureContext.php
@@ -2051,4 +2051,11 @@ class FeatureContext extends DrupalContext {
     }
   }
 
+  /**
+   * @Given /^I logout$/
+   */
+  public function iLogout() {
+    $this->visit('user/logout');
+  }
+
 }

--- a/openscholar/behat/features/bootstrap/FeatureHelper.php
+++ b/openscholar/behat/features/bootstrap/FeatureHelper.php
@@ -41,6 +41,7 @@ class FeatureHelp {
     'Faceted taxonomy' => 'os_boxes_facetapi_vocabulary',
     'List of posts' => 'os_sv_list_box',
     'List of publications' => 'os_sv_list_box',
+    'All Posts' => 'os_sv_list_box',
     'Cache time test' => 'os_boxes_cache_test',
   );
 

--- a/openscholar/behat/features/widgets/list_of_posts.feature
+++ b/openscholar/behat/features/widgets/list_of_posts.feature
@@ -26,6 +26,7 @@ Feature:
           | Display style            | Teaser | select list |
       And I logout
      When I visit "john/blog"
+      And I should print page
      Then I should see "John F. Kennedy: A Biography"
 
   @api @widgets
@@ -37,4 +38,6 @@ Feature:
       And I logout
      When I visit "john/blog"
      Then I should not see "John F. Kennedy: A Biography"
-
+          # Set the App back to "Public".
+      And I am logging in as "john"
+      And I set feature "edit-spaces-features-os-publications" to "Public" on "john"

--- a/openscholar/behat/features/widgets/list_of_posts.feature
+++ b/openscholar/behat/features/widgets/list_of_posts.feature
@@ -17,29 +17,3 @@ Feature:
      When I visit "john/blog"
      Then I should see "parent page"
       And I should see "child page"
-
-  @api @widgets
-  Scenario: Verify that anonymous user can see public bundles in the LOP.
-    Given I am logging in as "john"
-      And the widget "List of posts" is set in the "News" page with the following <settings>:
-          | Content Type             | All    | select list |
-          | Display style            | Teaser | select list |
-      And I logout
-     When I visit "john/news"
-     Then I should see "John F. Kennedy: A Biography"
-
-  @api @widgets
-  Scenario: Verify that anonymous user can not see private bundles in the LOP.
-    Given I am logging in as "john"
-      And I set feature "edit-spaces-features-os-publications" to "Private" on "john"
-    And the widget "List of posts" is set in the "News" page with the following <settings>:
-          | Content Type             | All    | select list |
-          | Display style            | Teaser | select list |
-      And I visit "john/news"
-      And I should see "John F. Kennedy: A Biography"
-      And I logout
-     When I visit "john/news"
-     Then I should not see "John F. Kennedy: A Biography"
-          # Set the App back to "Public".
-      And I am logging in as "john"
-      And I set feature "edit-spaces-features-os-publications" to "Public" on "john"

--- a/openscholar/behat/features/widgets/list_of_posts.feature
+++ b/openscholar/behat/features/widgets/list_of_posts.feature
@@ -17,3 +17,24 @@ Feature:
      When I visit "john/blog"
      Then I should see "parent page"
       And I should see "child page"
+
+  @api @widgets
+  Scenario: Verify that anonymous user can see public bundles in the LOP.
+    Given I am logging in as "john"
+      And the widget "List of posts" is set in the "Blog" page with the following <settings>:
+          | Content Type             | All    | select list |
+          | Display style            | Teaser | select list |
+      And I logout
+     When I visit "john/blog"
+     Then I should see "John F. Kennedy: A Biography"
+
+  @api @widgets
+  Scenario: Verify that anonymous user can not see private bundles in the LOP.
+    Given I am logging in as "john"
+      And I set feature "edit-spaces-features-os-publications" to "Private" on "john"
+      And I visit "john/blog"
+      And I should see "John F. Kennedy: A Biography"
+      And I logout
+     When I visit "john/blog"
+     Then I should not see "John F. Kennedy: A Biography"
+

--- a/openscholar/behat/features/widgets/list_of_posts.feature
+++ b/openscholar/behat/features/widgets/list_of_posts.feature
@@ -21,22 +21,24 @@ Feature:
   @api @widgets
   Scenario: Verify that anonymous user can see public bundles in the LOP.
     Given I am logging in as "john"
-      And the widget "List of posts" is set in the "Blog" page with the following <settings>:
+      And the widget "List of posts" is set in the "News" page with the following <settings>:
           | Content Type             | All    | select list |
           | Display style            | Teaser | select list |
       And I logout
-     When I visit "john/blog"
-      And I should print page
+     When I visit "john/news"
      Then I should see "John F. Kennedy: A Biography"
 
   @api @widgets
   Scenario: Verify that anonymous user can not see private bundles in the LOP.
     Given I am logging in as "john"
       And I set feature "edit-spaces-features-os-publications" to "Private" on "john"
-      And I visit "john/blog"
+    And the widget "List of posts" is set in the "News" page with the following <settings>:
+          | Content Type             | All    | select list |
+          | Display style            | Teaser | select list |
+      And I visit "john/news"
       And I should see "John F. Kennedy: A Biography"
       And I logout
-     When I visit "john/blog"
+     When I visit "john/news"
      Then I should not see "John F. Kennedy: A Biography"
           # Set the App back to "Public".
       And I am logging in as "john"

--- a/openscholar/behat/features/widgets/lop_privacy.feature
+++ b/openscholar/behat/features/widgets/lop_privacy.feature
@@ -9,21 +9,16 @@ Feature: foo
           | Display style            | Teaser | select list |
       And I logout
      When I visit "john/news"
-    And I should print page
      Then I should see "John F. Kennedy: A Biography"
 
   @api @widgets
-  Scenario: Verify that anonymous user can not see private bundles in the LOP.
+  Scenario: Verify that private bundles don't show up in the LOP.
     Given I am logging in as "john"
       And I set feature "edit-spaces-features-os-publications" to "Private" on "john"
       And the widget "All Posts" is set in the "News" page with the following <settings>:
           | Content Type             | All    | select list |
           | Display style            | Teaser | select list |
       And I visit "john/news"
-      And I should see "John F. Kennedy: A Biography"
-      And I logout
-     When I visit "john/news"
-     Then I should not see "John F. Kennedy: A Biography"
+      And I should not see "John F. Kennedy: A Biography"
           # Set the App back to "Public".
-      And I am logging in as "john"
       And I set feature "edit-spaces-features-os-publications" to "Public" on "john"

--- a/openscholar/behat/features/widgets/lop_privacy.feature
+++ b/openscholar/behat/features/widgets/lop_privacy.feature
@@ -1,0 +1,29 @@
+Feature: foo
+  Verify that privacy of bundles is respected in the LOP widget.
+
+  @api @widgets
+  Scenario: Verify that anonymous user can see public bundles in the LOP.
+    Given I am logging in as "john"
+      And the widget "All Posts" is set in the "News" page with the following <settings>:
+          | Content Type             | All    | select list |
+          | Display style            | Teaser | select list |
+      And I logout
+     When I visit "john/news"
+    And I should print page
+     Then I should see "John F. Kennedy: A Biography"
+
+  @api @widgets
+  Scenario: Verify that anonymous user can not see private bundles in the LOP.
+    Given I am logging in as "john"
+      And I set feature "edit-spaces-features-os-publications" to "Private" on "john"
+      And the widget "All Posts" is set in the "News" page with the following <settings>:
+          | Content Type             | All    | select list |
+          | Display style            | Teaser | select list |
+      And I visit "john/news"
+      And I should see "John F. Kennedy: A Biography"
+      And I logout
+     When I visit "john/news"
+     Then I should not see "John F. Kennedy: A Biography"
+          # Set the App back to "Public".
+      And I am logging in as "john"
+      And I set feature "edit-spaces-features-os-publications" to "Public" on "john"

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -407,19 +407,45 @@ abstract class os_boxes_default extends boxes_box {
    *  FALSE otherwise.
    */
   public function checkWidgetAccess($bundle) {
-    $public_bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
-    $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+    $bundles = $this->getBundles();
 
-    if (in_array($bundle, $public_bundles)) {
+    if (in_array($bundle, $bundles['public_bundles'])) {
       // Widget displays a single public bundle.
       return TRUE;
     }
 
-    if (in_array($bundle, $private_bundles)) {
+    if (in_array($bundle, $bundles['private_bundles'])) {
       // Widget displays a single private bundle.
       return node_access('view', $bundle);
     }
     return TRUE;
+  }
+
+  /**
+   * Get the associated bundles for an App type.
+   *
+   * @param $app_type
+   *  The App type to get the bundles for. Can be OS_PRIVATE_APP to get the
+   *  private bundles or OS_PUBLIC_APP to get the public bundles. If empty, get
+   *  all the bundles.
+   *
+   * @return array
+   *  An array keyed by the app type and valued with the matching bundles.
+   */
+  protected function getBundles($app_type = '') {
+    switch ($app_type) {
+      case OS_PRIVATE_APP:
+        $bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+        break;
+      case OS_PUBLIC_APP:
+        $bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+        break;
+      default:
+        $bundles['public_bundles'] = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+        $bundles['private_bundles'] = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+        break;
+    }
+    return $bundles;
   }
 }
 

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -147,9 +147,6 @@ abstract class os_boxes_default extends boxes_box {
       $this->cache_id .= ':' . $page;
     }
 
-    global $user;
-    $this->cache_id .= ':' . $user->uid;
-
     return $this->cache_id;
   }
 

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -147,6 +147,9 @@ abstract class os_boxes_default extends boxes_box {
       $this->cache_id .= ':' . $page;
     }
 
+    global $user;
+    $this->cache_id .= ':' . $user->uid;
+
     return $this->cache_id;
   }
 

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -398,6 +398,35 @@ abstract class os_boxes_default extends boxes_box {
 
     return $this->os_contexts;
   }
+
+  /**
+   * Check access to the the box.
+   *
+   * @param $bundle
+   *  The bundle displayed in the widget.
+   *
+   * @return bool
+   *  Returns TRUE if the user can view the widget's content.
+   *  FALSE otherwise.
+   */
+  public function checkWidgetAccess($bundle) {
+    $public_bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+    $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+
+    if (!empty($bundle) && in_array($bundle, $public_bundles)) {
+      // Widget displays a single public bundle.
+      return TRUE;
+    }
+
+    // Widget displays all bundles so check if the user is allowed the view the
+    // private bundles.
+    foreach ($private_bundles as $private_bundle) {
+      if (!node_access('view', $private_bundle)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
 }
 
 function _os_boxes_default_advanced_handler($element, $form_state) {

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -410,17 +410,14 @@ abstract class os_boxes_default extends boxes_box {
     $public_bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
     $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
 
-    if (!empty($bundle) && in_array($bundle, $public_bundles)) {
+    if (in_array($bundle, $public_bundles)) {
       // Widget displays a single public bundle.
       return TRUE;
     }
 
-    // Widget displays all bundles so check if the user is allowed the view the
-    // private bundles.
-    foreach ($private_bundles as $private_bundle) {
-      if (!node_access('view', $private_bundle)) {
-        return FALSE;
-      }
+    if (in_array($bundle, $private_bundles)) {
+      // Widget displays a single private bundle.
+      return node_access('view', $bundle);
     }
     return TRUE;
   }

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_taxonomy_fbt/os_taxonomy_fbt.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_taxonomy_fbt/os_taxonomy_fbt.inc
@@ -282,8 +282,8 @@ class os_taxonomy_fbt extends os_boxes_default {
     }
 
     // Check user access to the content of the widget.
-    if (!$this->checkWidgetAccess(reset($this->options['bundles']))) {
-      return;
+    if (!empty($this->options['bundles']) && !$this->checkWidgetAccess(reset($this->options['bundles']))) {
+      return $block;
     }
 
     $id = 'vocabulary:' . $this->options['vocabulary'];

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_taxonomy_fbt/os_taxonomy_fbt.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_taxonomy_fbt/os_taxonomy_fbt.inc
@@ -280,6 +280,12 @@ class os_taxonomy_fbt extends os_boxes_default {
         $this->options['bundles'] = array($bundles);
       }
     }
+
+    // Check user access to the content of the widget.
+    if (!$this->checkWidgetAccess(reset($this->options['bundles']))) {
+      return;
+    }
+
     $id = 'vocabulary:' . $this->options['vocabulary'];
     $this->set_cache_id($id);
     if (($block['content'] = $this->get_cache()) === FALSE) {

--- a/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
+++ b/openscholar/modules/os/modules/os_sv_list/os_sv_list.module
@@ -266,3 +266,29 @@ function os_sv_list_terms_element_validate($element, &$form_state) {
 function os_sv_list_vocabs_content_type($form, $form_state) {
   return $form['options']['vocabs'];
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function os_sv_list_form_spaces_features_form_alter(&$form, &$form_state) {
+  $form['#submit'][] = 'os_sv_list_form_spaces_features_form_submit';
+}
+
+/**
+ * Submit handler.
+ *
+ * Invalidate the os_boxes cache to make sure that apps that are now private
+ * won't display content in the LOP
+ */
+function os_sv_list_form_spaces_features_form_submit($form, &$form_state) {
+  $cid = 'os_boxes_cache:';
+  if (module_exists('vsite') && $vsite = vsite_get_vsite()) {
+    $cid .= $vsite->id;
+  }
+
+  // Flush raw data.
+  cache_clear_all($cid, 'cache_os_boxes', TRUE);
+
+  // Flush assets.
+  cache_clear_all('assets:' . $cid, 'cache_os_boxes', TRUE);
+}

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -229,19 +229,20 @@ class os_sv_list extends os_boxes_default {
   }
 
   public function render() {
-    if (module_exists('vsite') && !(vsite_get_vsite())) {
+    if (module_exists('vsite') && !vsite_get_vsite()) {
       return;
     }
+
+    $block = parent::render();
 
     $bundle = ($this->options['content_type'] != 'all') ? $this->options['content_type'] : NULL;
     $cid = $bundle ? 'node:' . $bundle : NULL;
 
     // Check user access to the content of the widget.
-    if (!$this->checkWidgetAccess($bundle)) {
-      return;
+    if (!empty($bundle) && !$this->checkWidgetAccess($bundle)) {
+      return $block;
     }
 
-    $block = parent::render();
     $page_num = pager_find_page(PagerDefault::$maxElement);
 
     $this->set_cache_id($cid, $page_num);
@@ -354,6 +355,19 @@ class os_sv_list extends os_boxes_default {
     if ($this->options['content_type'] != 'all') {
       // Any special hook here?
       $query->propertyCondition('type', $this->options['content_type']);
+    }
+    else {
+      // When "All" is selected show only public bundles and private bundles
+      // for the privileged users.
+      $bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+      $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+
+      foreach ($private_bundles as $private_bundle) {
+        if (node_access('view', $private_bundle)) {
+          $bundles[] = $private_bundle;
+        }
+      }
+      $query->propertyCondition('type', $bundles, 'IN');
     }
 
     // Pager.

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -227,9 +227,9 @@ class os_sv_list extends os_boxes_default {
 
     return $form;
   }
-    
+
   public function render() {
-    if (module_exists('vsite') && !($vsite = vsite_get_vsite())) {
+    if (module_exists('vsite') && !(vsite_get_vsite())) {
       return;
     }
 

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -362,8 +362,9 @@ class os_sv_list extends os_boxes_default {
       $bundles = $this->getBundles(OS_PUBLIC_APP);
       $private_bundles = $this->getBundles(OS_PRIVATE_APP);
 
+      $vsite = vsite_get_vsite();
       foreach ($private_bundles as $private_bundle) {
-        if (node_access('view', $private_bundle)) {
+        if (og_user_access('node', $vsite->id, "view $private_bundle content")) {
           $bundles[] = $private_bundle;
         }
       }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -237,7 +237,7 @@ class os_sv_list extends os_boxes_default {
     $cid = $bundle ? 'node:' . $bundle : NULL;
 
     // Check user access to the content of the widget.
-    if (!$this->checkWidgetAccess($bundle, $vsite)) {
+    if (!$this->checkWidgetAccess($bundle)) {
       return;
     }
 
@@ -296,7 +296,7 @@ class os_sv_list extends os_boxes_default {
       $entities = entity_load($this->entity_type, $ids);
       $entities = array_map(function ($e) { $e->sv_list = TRUE; return $e; }, $entities);
       $this->_plugins_invoke('entities_alter', $entities);
-      
+
       // If we have entities render them out, otherwise cache (null) as the content.
       if (!empty($entities)) {
         
@@ -649,34 +649,4 @@ class os_sv_list extends os_boxes_default {
     array_unshift($sorts, $sticky);
   }
 
-  /**
-   * Check access to the LOP widget.
-   *
-   * @param $bundle
-   *  The bundle displayed in the widget.
-   * @param $vsite
-   *  The VSite the widget is displayed in.
-
-   * @return bool
-   *  Returns TRUE if the user can view the widget's content.
-   *  FALSE otherwise.
-   */
-  private function checkWidgetAccess($bundle, $vsite) {
-    $public_bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
-    $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
-
-    if (!empty($bundle) && in_array($bundle, $public_bundles)) {
-      // Widget displays a single public bundle.
-      return TRUE;
-    }
-
-    // Widget displays all bundles so check if the user is allowed the view the
-    // private bundles.
-    foreach ($private_bundles as $private_bundle) {
-      if (!og_user_access('node', $vsite->id, "view $private_bundle content")) {
-        return FALSE;
-      }
-    }
-    return TRUE;
-  }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -229,12 +229,17 @@ class os_sv_list extends os_boxes_default {
   }
     
   public function render() {
-    if (module_exists('vsite') && !vsite_get_vsite()) {
+    if (module_exists('vsite') && !($vsite = vsite_get_vsite())) {
       return;
     }
 
     $bundle = ($this->options['content_type'] != 'all') ? $this->options['content_type'] : NULL;
     $cid = $bundle ? 'node:' . $bundle : NULL;
+
+    // Check user access to the content of the widget.
+    if (!$this->checkWidgetAccess($bundle, $vsite)) {
+      return;
+    }
 
     $block = parent::render();
     $page_num = pager_find_page(PagerDefault::$maxElement);
@@ -642,5 +647,36 @@ class os_sv_list extends os_boxes_default {
 
     // Add the sort by sticky to be the first sort.
     array_unshift($sorts, $sticky);
+  }
+
+  /**
+   * Check access to the LOP widget.
+   *
+   * @param $bundle
+   *  The bundle displayed in the widget.
+   * @param $vsite
+   *  The VSite the widget is displayed in.
+
+   * @return bool
+   *  Returns TRUE if the user can view the widget's content.
+   *  FALSE otherwise.
+   */
+  private function checkWidgetAccess($bundle, $vsite) {
+    $public_bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+    $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+
+    if (!empty($bundle) && in_array($bundle, $public_bundles)) {
+      // Widget displays a single public bundle.
+      return TRUE;
+    }
+
+    // Widget displays all bundles so check if the user is allowed the view the
+    // private bundles.
+    foreach ($private_bundles as $private_bundle) {
+      if (!og_user_access('node', $vsite->id, "view $private_bundle content")) {
+        return FALSE;
+      }
+    }
+    return TRUE;
   }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -359,8 +359,8 @@ class os_sv_list extends os_boxes_default {
     else {
       // When "All" is selected show only public bundles and private bundles
       // for the privileged users.
-      $bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
-      $private_bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+      $bundles = $this->getBundles(OS_PUBLIC_APP);
+      $private_bundles = $this->getBundles(OS_PRIVATE_APP);
 
       foreach ($private_bundles as $private_bundle) {
         if (node_access('view', $private_bundle)) {

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -357,17 +357,8 @@ class os_sv_list extends os_boxes_default {
       $query->propertyCondition('type', $this->options['content_type']);
     }
     else {
-      // When "All" is selected show only public bundles and private bundles
-      // for the privileged users.
+      // When "All" is selected show only public bundles.
       $bundles = $this->getBundles(OS_PUBLIC_APP);
-      $private_bundles = $this->getBundles(OS_PRIVATE_APP);
-
-      $vsite = vsite_get_vsite();
-      foreach ($private_bundles as $private_bundle) {
-        if (og_user_access('node', $vsite->id, "view $private_bundle content")) {
-          $bundles[] = $private_bundle;
-        }
-      }
       $query->propertyCondition('type', $bundles, 'IN');
     }
 

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
@@ -63,52 +63,11 @@ class os_sv_list_file extends os_sv_list {
   /**
    * Check access to the the box.
    *
-   * We return here TRUE because in the case of file we need to check if the
-   * linked nodes are of a bundle (App) that is set to private. This will be
-   * done in the get_ids() method.
+   * We return here TRUE because in the case of file, a public file attached to a
+   * private bundle would still be considered public.
    */
   public function checkWidgetAccess($bundle) {
     return TRUE;
   }
 
-  /**
-   * Overrides os_sv_list::get_ids().
-   */
-  public function get_ids($page) {
-    $ids = parent::get_ids($page);
-
-    if (!$ids) {
-      return array();
-    }
-
-    // Get the bundle of the nodes that are using the files with the given ids.
-    $query = db_select('node', 'n');
-    $query->join('file_usage', 'fu', 'n.nid = fu.id');
-    $query->fields('n', array('type'));
-    $query->condition('fu.fid', $ids, 'IN');
-    $results = $query
-      ->execute()
-      ->fetchAll();
-
-    $attached_nodes_bundles = array();
-    foreach ($results as $result) {
-      $attached_nodes_bundles[] = $result->type;
-    }
-
-    // Get the node bundles that use the files which are private.
-    $private_bundles_using_files = array_intersect($attached_nodes_bundles, array_keys(os_get_bundles(array(OS_PRIVATE_APP))));
-    if (empty($private_bundles_using_files)) {
-      return $ids;
-    }
-
-    // We have files that are used in a bundle (App) that is private so check to
-    // see if the user has access to view it.
-    foreach ($private_bundles_using_files as $private_bundle) {
-      if (!node_access('view', $private_bundle)) {
-        $ids = array();
-        break;
-      }
-    }
-    return $ids;
-  }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
@@ -71,7 +71,7 @@ class os_sv_list_file extends os_sv_list {
    *  FALSE otherwise.
    */
   public function checkWidgetAccess($bundle) {
-
+    // @TODO
     return true;
   }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
@@ -63,15 +63,52 @@ class os_sv_list_file extends os_sv_list {
   /**
    * Check access to the the box.
    *
-   * @param $bundle
-   *  The bundle displayed in the widget.
-   *
-   * @return bool
-   *  Returns TRUE if the user can view the widget's content.
-   *  FALSE otherwise.
+   * We return here TRUE because in the case of file we need to check if the
+   * linked nodes are of a bundle (App) that is set to private. This will be
+   * done in the get_ids() method.
    */
   public function checkWidgetAccess($bundle) {
-    // @TODO
-    return true;
+    return TRUE;
+  }
+
+  /**
+   * Overrides os_sv_list::get_ids().
+   */
+  public function get_ids($page) {
+    $ids = parent::get_ids($page);
+
+    if (!$ids) {
+      return array();
+    }
+
+    // Get the bundle of the nodes that are using the files with the given ids.
+    $query = db_select('node', 'n');
+    $query->join('file_usage', 'fu', 'n.nid = fu.id');
+    $query->fields('n', array('type'));
+    $query->condition('fu.fid', $ids, 'IN');
+    $results = $query
+      ->execute()
+      ->fetchAll();
+
+    $attached_nodes_bundles = array();
+    foreach ($results as $result) {
+      $attached_nodes_bundles[] = $result->type;
+    }
+
+    // Get the node bundles that use the files which are private.
+    $private_bundles_using_files = array_intersect($attached_nodes_bundles, array_keys(os_get_bundles(array(OS_PRIVATE_APP))));
+    if (empty($private_bundles_using_files)) {
+      return $ids;
+    }
+
+    // We have files that are used in a bundle (App) that is private so check to
+    // see if the user has access to view it.
+    foreach ($private_bundles_using_files as $private_bundle) {
+      if (!node_access('view', $private_bundle)) {
+        $ids = array();
+        break;
+      }
+    }
+    return $ids;
   }
 }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list_file.inc
@@ -59,5 +59,19 @@ class os_sv_list_file extends os_sv_list {
   function sort_filesize(&$efq) {
     $efq->propertyOrderBy('filesize', 'DESC');
   }
-  
+
+  /**
+   * Check access to the the box.
+   *
+   * @param $bundle
+   *  The bundle displayed in the widget.
+   *
+   * @return bool
+   *  Returns TRUE if the user can view the widget's content.
+   *  FALSE otherwise.
+   */
+  public function checkWidgetAccess($bundle) {
+
+    return true;
+  }
 }


### PR DESCRIPTION
#7133 

In this PR we check the persmission of users to view the displayed bundle in the LOP, before displaying the widget on the page. For example, on the next site all apps are public. The admin of the site and an anonymous user see:
![selection_025](https://cloud.githubusercontent.com/assets/4497748/7385164/08ff9d4e-ee73-11e4-9a35-a78573c67dda.png)
![selection_029](https://cloud.githubusercontent.com/assets/4497748/7385163/08e3c86c-ee73-11e4-9449-f6c5578bd155.png)

Now the site admin changes the visability of events to "private":
![selection_028](https://cloud.githubusercontent.com/assets/4497748/7385172/2eadf8f6-ee73-11e4-8b0a-f82540ec68d7.png)

Submitting the form invalidates the os_boxes cache and now the anonymous user will see:
![selection_027](https://cloud.githubusercontent.com/assets/4497748/7385176/46d1bb34-ee73-11e4-8ce1-e6a17a059186.png)


