### PR TITLE
Fix fatal error when clicking "Cancel" in a node form.

### DIFF
--- a/openscholar/behat/features/misc/cancel_redirects.feature
+++ b/openscholar/behat/features/misc/cancel_redirects.feature
@@ -8,3 +8,11 @@ Feature:
       And I visit "john/node/add/page"
       And I click "Cancel"
      Then I should be on "john"
+
+  @api @misc_first
+  Scenario: Test redirect when user clicks "cancel" in a node form.
+    Given I am logging in as "john"
+      And I visit "john/event/testing-event"
+      And I edit the node "halley's comet"
+     When I click "Cancel"
+     Then I should be on "john/calendar"

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -902,8 +902,10 @@ function os_form_alter(&$form, &$form_state, $form_id) {
         $destination = '';
       }
     }
+    // We don't need the query string in the destination.
+    $destination = strtok($destination, "?");
     $form['actions']['cancel'] = array(
-      '#markup'   => '<a class="form-cancel" href="' . urldecode(url($destination)) . '">' . t('Cancel') . '</a>',
+      '#markup'   => l(t('Cancel'), $destination, array('attributes' => array('class' => 'form-cancel'))),
       '#weight' => 99,
     );
   }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -903,9 +903,9 @@ function os_form_alter(&$form, &$form_state, $form_id) {
       }
     }
     // We don't need the query string in the destination.
-    $destination = strtok($destination, "?");
+    list($path) = explode('?', $destination);
     $form['actions']['cancel'] = array(
-      '#markup'   => l(t('Cancel'), $destination, array('attributes' => array('class' => 'form-cancel'))),
+      '#markup' => l(t('Cancel'), $path, array('attributes' => array('class' => 'form-cancel'))),
       '#weight' => 99,
     );
   }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -903,7 +903,7 @@ function os_form_alter(&$form, &$form_state, $form_id) {
       }
     }
     $form['actions']['cancel'] = array(
-      '#markup'   => l(t('Cancel'), $destination, array('attributes' => array('class' => 'form-cancel'))),
+      '#markup'   => '<a class="form-cancel" href="' . urldecode(url($destination)) . '">' . t('Cancel') . '</a>',
       '#weight' => 99,
     );
   }


### PR DESCRIPTION
#7150 

This PR fixes the fatal error caused when editing a post. If the post is in a page with the "os_events" view (the "upcoming events" widget) we get query parameters that cause ``og_ui`` to cause a fatal error. This has to do with the way that module generates its menu items.

Avoiding the encoding of the url of the cancel button fixed it. I didn't get an error when hitting the X button.