### PR TITLE
Fix "more" link not showing in LOP for events.

### DIFF
--- a/openscholar/behat/features/bootstrap/FeatureHelper.php
+++ b/openscholar/behat/features/bootstrap/FeatureHelper.php
@@ -41,6 +41,7 @@ class FeatureHelp {
     'Faceted taxonomy' => 'os_boxes_facetapi_vocabulary',
     'List of posts' => 'os_sv_list_box',
     'List of publications' => 'os_sv_list_box',
+    'Upcoming events' => 'os_sv_list_box',
     'Cache time test' => 'os_boxes_cache_test',
   );
 

--- a/openscholar/behat/features/widgets/lop_upcoming_events.feature
+++ b/openscholar/behat/features/widgets/lop_upcoming_events.feature
@@ -24,3 +24,17 @@ Feature:
       And I visit "john/event/repeating-event?delta=2"
       And I should see the date of the "2" repeat of the event
       And I should see "Repeats every week 3 times."
+
+  @api @widgets
+  Scenario: Verify that the List of posts widget shows a "more" link when showing
+            events with number of repeats higher than the number of items to be
+            displayed.
+    Given I am logging in as "john"
+     When I create a new repeating event with title "Another Repeating event" that repeats "5" times
+      And the widget "Upcoming events" is set in the "Software" page with the following <settings>:
+          | Content Type               | Event  | select list |
+          | Display style              | Title  | select list |
+          | more                       | check  | checkbox    |
+          | Number of items to display | 3      | select list |
+      And I visit "john/software"
+     Then I should see "more"

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -280,9 +280,10 @@ class os_sv_list extends os_boxes_default {
       drupal_add_js(drupal_get_path('module', 'os_sv_list') . '/os_sv_list_display.js');
 
       // Truncate items and prepare the more link.
-      $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
+      $more = '';
       if (count($ids) > $this->options['number_of_items'] || ($this->options['pager'] && $ids && $pager_current < $pager_max)) {
         $ids = array_slice($ids, 0, $this->options['number_of_items']);
+        $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
       }
 
       // Give plugins a chance to alter the entities after loading but before

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -279,11 +279,18 @@ class os_sv_list extends os_boxes_default {
       drupal_add_library('system', 'drupal.ajax');
       drupal_add_js(drupal_get_path('module', 'os_sv_list') . '/os_sv_list_display.js');
 
-      // Truncate items and prepare the more link.
+      // Prepare the more link.
       $more = '';
+      $plugin_name = $this->entity_type . '_' . $bundle;
+      $actual_ids = $this->_plugins_invoke('get_number_of_results');
+      $actual_ids = !empty($actual_ids[$plugin_name]) ? $actual_ids[$plugin_name] : $ids;
+      if ($actual_ids > $this->options['number_of_items']) {
+        $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
+      }
+
+      // Truncate items.
       if (count($ids) > $this->options['number_of_items'] || ($this->options['pager'] && $ids && $pager_current < $pager_max)) {
         $ids = array_slice($ids, 0, $this->options['number_of_items']);
-        $more = ($this->options['more']) ? l($this->options['more_text'], $this->options['more_link'], array('attributes' => array('class' => array('more-link')))) : '';
       }
 
       // Give plugins a chance to alter the entities after loading but before

--- a/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
@@ -156,6 +156,17 @@ class sv_list_node_event extends sv_list_plugin  {
     }
   }
 
+  /**
+   * Get the number of query results for the plugin.
+   *
+   * In case of events we need this number of results to determine if the "more"
+   * link should be displayed. This is because repeated events are counted only
+   * once when counting node IDs, and this can cause the link to not be showed
+   * when it actually should.
+   *
+   * @return int
+   *   Number of query results.
+   */
   public function get_number_of_results() {
     return count($this->query->ordered_results);
   }

--- a/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/sv_list/node_event.inc
@@ -155,4 +155,8 @@ class sv_list_node_event extends sv_list_plugin  {
       $cache_time = "5 minutes";
     }
   }
+
+  public function get_number_of_results() {
+    return count($this->query->ordered_results);
+  }
 }


### PR DESCRIPTION
#7129

This PR adds the "More" link to the LOP. The display of the link was conditioned on the number of entity IDs we display. This caused inconsistent results when dealing with events since repeated events.
So, we now add the more link according to the setting of the widget with regardless of the node IDs:
![selection_047](https://cloud.githubusercontent.com/assets/4497748/7509225/52e8bb36-f4c0-11e4-8fda-fae02ecdf106.png)
![selection_046](https://cloud.githubusercontent.com/assets/4497748/7509226/53178ff6-f4c0-11e4-8aff-1d8962e1531b.png)

Also, while working on it I found a bug that's fixed here - 
When getting the entities for events, we iterate over the results of the query. The number of results can be bigger that the number of entities we display so some logic was needed there to handle that.