### PR TITLE
Adding integration to API doc.

### DIFF
--- a/openscholar/modules/os/modules/os_restful/apidoc.json
+++ b/openscholar/modules/os/modules/os_restful/apidoc.json
@@ -1,0 +1,12 @@
+{
+  "name": "OpenScholar Restful documentation",
+  "version": "0.1.0",
+  "description": "This is an example on how to interact with OpenScholar Restful end point.",
+  "title": "Custom apiDoc browser title",
+  "url" : "http://localhost/OpenScholarMake/www/api",
+  "sampleUrl": "http://localhost/OpenScholarMake/www/api",
+  "template": {
+  	"withCompare": true,
+  	"withGenerator": true
+  }
+}

--- a/openscholar/modules/os/modules/os_restful/plugins/restful/node/biblio/1.0/BiblioNodeRestfulBase.class.php
+++ b/openscholar/modules/os/modules/os_restful/plugins/restful/node/biblio/1.0/BiblioNodeRestfulBase.class.php
@@ -2,6 +2,23 @@
 
 class BiblioNodeRestfulBase extends OsNodeRestfulBase {
 
+  /**
+   * @api {get} /biblio/:id Biblio
+   * @apiVersion 0.1.0
+   * @apiName GetEndpoints
+   * @apiGroup Content
+   *
+   * @apiDescription Consume publications content.
+   *
+   * @apiParam {Number} id The publication ID
+   *
+   * @apiSuccess {Number}   id        The publication ID.
+   * @apiSuccess {String}   label     Registration Date.
+   * @apiSuccess {Object}   vsite     The vsite object.
+   * @apiSuccess {string}   body      The body of the publication.
+   * @apiSuccess {Object[]} files     The attached files.
+   * @apiSuccess {Integer}  type      The publication type ID.
+   */
   public function publicFieldsInfo() {
     $public_fields = parent::publicFieldsInfo();
 


### PR DESCRIPTION
#7167 

Well, the API doc is awesome and not just because it's generate from the classes, but because we have a built in form that will return the output of the json:
![selection_406](https://cloud.githubusercontent.com/assets/1222368/7669715/e676f97c-fc8a-11e4-9e69-67964acc4d5f.png)
![selection_407](https://cloud.githubusercontent.com/assets/1222368/7669716/e8214476-fc8a-11e4-8353-a21cadcdaf95.png)

For now, my local address is hard coded to the api json file but we will need to change it to address from one of OpenScholar installations. - ``"url" : "http://localhost/OpenScholarMake/www/api",``

I wanted to add grunt task manager, during the edit, upon each file change the doc will reload. I understood the grunt project wasn't updated in the past year and instead the JS community embraced gulp. The good thing is gulp is updated and grunt not. The problem is that i don't know if gulp have all the task ready for this initiative. 

Another thing is that restful know how to output all the fields with the definitions built in but this need be taken from address and i don't know, yet, if api doc know how to compile from address and in another formats.

I'll also need gh-pages ready to use in the repo for api doc.