### PR TITLE
Add <th> and <thead> tags to allowed html tag list.

### DIFF
--- a/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.features.filter.inc
+++ b/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.features.filter.inc
@@ -36,6 +36,8 @@ function os_wysiwyg_filter_default_formats() {
     table[style|border|align<center?left?right|cellpadding|cellspacing|bgcolor],
     tr[align<center?justify?left?right|valign],
     td[colspan|rowspan|align<center?justify?left?right|valign],
+    th[colspan|rowspan|align<center?justify?left?right|valign],
+    thead,
     caption,
     address,h2,h3,h4,h5,h6,pre,
     strong/b,em/i,strike,u',

--- a/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.install
+++ b/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.install
@@ -63,3 +63,10 @@ function os_wysiwyg_update_7004() {
 
   features_revert(array_fill_keys($modules, $reset));
 }
+
+/**
+ * Revert os_wysiwyg filter component to allow <th> and <thead> tags.
+ */
+function os_wysiwyg_update_7005() {
+  module_disable(array('os_wysiwyg', 'filter'));
+}


### PR DESCRIPTION
#7173 

This PR adds the ``<th>`` and ``<thead>`` tags to the allowed html tag list:
![selection_076](https://cloud.githubusercontent.com/assets/4497748/7674436/a2fad904-fd5a-11e4-88d2-f99dde38386f.png)

As a sidenote, just setting a row as header did nothing before the change in this PR. A row set as "header" was still a plain row with ``<td>`` and not ``<th>`` elements. One needs to actually manually change the td to th, or use the cell properties to change it from data cell to header cell. 