### PR TITLE
Remove the email form the site info box.

### DIFF
--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
@@ -67,10 +67,10 @@ class os_boxes_site_info extends os_boxes_default {
       '#description' => t('Ex. Cambridge, MA 02138'),
     );
 
-    $form['contact_anonymous'] = array(
+    $form['contact'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable contact form.'),
-      '#default_value' => variable_get('vsite_users_contact_form_anonymous', FALSE),
+      '#default_value' => variable_get('show_email', FALSE),
       '#description' => t('Will print an (email) link to your contact form.'),
     );
 
@@ -94,7 +94,7 @@ class os_boxes_site_info extends os_boxes_default {
     }
     $block = parent::render();
 
-    $anon_contact = variable_get('vsite_users_contact_form_anonymous', true);
+    $contact = variable_get('show_email', FALSE);
     if (module_exists('vsite') && $vsite = spaces_get_space()) {
       $group = $vsite->group;
       $addr = field_get_items('node', $group, 'field_site_address');
@@ -114,7 +114,7 @@ class os_boxes_site_info extends os_boxes_default {
     '.(!empty($this->options['descrip'])?'<h2>'.filter_xss($this->options['descrip'], $tags).'</h2>':'').'
     <p>'.((!empty($this->options['address1']) || !empty($this->options['address2']))?
         filter_xss($this->options['address1']).'<br>'.filter_xss($this->options['address2']):'').'
-    '. ($anon_contact ? l('(email)', 'contact_owner') : '' . '</p>');
+    '. ($contact ? l('(email)', 'contact_owner') : '' . '</p>');
 
     $block['content'] = $output;
     return $block;
@@ -142,7 +142,7 @@ function os_boxes_site_info_submit($form, &$form_state) {
 
     try {
       node_save($node);
-      $space->controllers->variable->set('vsite_users_contact_form_anonymous', $form_state['values']['contact_anonymous']);
+      $space->controllers->variable->set('show_email', $form_state['values']['contact']);
     }
     catch (Exception $e) {
       drupal_set_message(t('Error saving site information. Contact your site administrator.'), 'error');
@@ -151,6 +151,6 @@ function os_boxes_site_info_submit($form, &$form_state) {
   }
   else {
     boxes_box_form_submit($form, $form_state);
-    variable_set('vsite_users_contact_form_anonymous', $form_state['values']['contact_anonymous']);
+    variable_set('show_email', $form_state['values']['contact']);
   }
 }

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
@@ -70,7 +70,7 @@ class os_boxes_site_info extends os_boxes_default {
     $form['contact'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable contact form.'),
-      '#default_value' => variable_get('show_email', FALSE),
+      '#default_value' => variable_get('show_email', variable_get('vsite_users_contact_form_anonymous', TRUE)),
       '#description' => t('Will print an (email) link to your contact form.'),
     );
 
@@ -94,7 +94,7 @@ class os_boxes_site_info extends os_boxes_default {
     }
     $block = parent::render();
 
-    $contact = variable_get('show_email', FALSE);
+    $contact = variable_get('show_email', variable_get('vsite_users_contact_form_anonymous', TRUE));
     if (module_exists('vsite') && $vsite = spaces_get_space()) {
       $group = $vsite->group;
       $addr = field_get_items('node', $group, 'field_site_address');

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
@@ -67,6 +67,13 @@ class os_boxes_site_info extends os_boxes_default {
       '#description' => t('Ex. Cambridge, MA 02138'),
     );
 
+    $form['contact_anonymous'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable contact form.'),
+      '#default_value' => variable_get('vsite_users_contact_form_anonymous', FALSE),
+      '#description' => t('Will print an (email) link to your contact form.'),
+    );
+
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Save'),
@@ -101,13 +108,13 @@ class os_boxes_site_info extends os_boxes_default {
       ));
     }
 
-    $output = '';
     $tags = array('br', 'a', 'em', 'strong', 'cite', 'blockquote', 'code', 'ul', 'ol', 'li', 'dl', 'dt', 'dd');
 
     $output = '<h1>'.l($this->options['site_title'], '<front>').'</h1>
     '.(!empty($this->options['descrip'])?'<h2>'.filter_xss($this->options['descrip'], $tags).'</h2>':'').'
     <p>'.((!empty($this->options['address1']) || !empty($this->options['address2']))?
-        filter_xss($this->options['address1']).'<br>'.filter_xss($this->options['address2']):'').'</p>';
+        filter_xss($this->options['address1']).'<br>'.filter_xss($this->options['address2']):'').'
+    '. ($anon_contact ? l('(email)', 'contact_owner') : '' . '</p>');
 
     $block['content'] = $output;
     return $block;

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_site_info/os_boxes_site_info.inc
@@ -67,14 +67,6 @@ class os_boxes_site_info extends os_boxes_default {
       '#description' => t('Ex. Cambridge, MA 02138'),
     );
 
-    $form['contact_anonymous'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Enable contact form for Logged Out users.'),
-      '#default_value' => variable_get('vsite_users_contact_form_anonymous', true),
-      '#description' => t('Will print an (email) link to your contact form when a visitor is not logged in.
-        Logged in users will always see the link.'),
-    );
-
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Save'),
@@ -115,8 +107,7 @@ class os_boxes_site_info extends os_boxes_default {
     $output = '<h1>'.l($this->options['site_title'], '<front>').'</h1>
     '.(!empty($this->options['descrip'])?'<h2>'.filter_xss($this->options['descrip'], $tags).'</h2>':'').'
     <p>'.((!empty($this->options['address1']) || !empty($this->options['address2']))?
-        filter_xss($this->options['address1']).'<br>'.filter_xss($this->options['address2']):'').'
-    '.((user_is_logged_in() || $anon_contact)?l('(email)', 'contact_owner'):'').'</p>';
+        filter_xss($this->options['address1']).'<br>'.filter_xss($this->options['address2']):'').'</p>';
 
     $block['content'] = $output;
     return $block;


### PR DESCRIPTION
#7170 

In this PR we remove the option to display the email link in the site info widget.
Before:
![selection_078](https://cloud.githubusercontent.com/assets/4497748/7675204/1929d06e-fd68-11e4-8f65-a71f3a44acb4.png)

After:
![selection_079](https://cloud.githubusercontent.com/assets/4497748/7675206/1f7521ee-fd68-11e4-8309-e44ca3dae4f5.png)
