### PR TITLE
Use vocab name and term name instead of TID and VID.

### DIFF
--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -504,15 +504,8 @@ function theme_os_taxonomy_vocabulary_item_list($variables) {
 
       // Handle events.
       if (strpos(current($options['bundles']), 'event') !== FALSE) {
-        // Get the term alias.
-        $result = db_select('url_alias')
-          ->fields('url_alias', array('alias'))
-          ->condition('source', 'taxonomy/term/' . $tid)
-          ->execute()
-          ->fetchAssoc();
-
-        // Remove the PURL from the alias.
-        $term_alias = $result['alias'];
+        // Get the term alias and remove the PURL from the alias.
+        $term_alias = drupal_lookup_path('alias', 'taxonomy/term/' . $term->tid);
         $parts = explode('/', $term_alias);
         array_shift($parts);
         $term_alias = implode('/', $parts);

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -91,12 +91,12 @@ function os_taxonomy_taxonomy_term_uri($term) {
  */
 function os_taxonomy_views_query_alter(&$view, &$query) {
   if (!$path = os_taxonomy_in_taxonomy_term_context($view)) {
-
-    //If this view takes arguments we can't be sure that this is a 404, we will let the view decide.
+    // If this view takes arguments we can't be sure that this is a 404, we will
+    // let the view decide.
     $view_takes_arguments = (isset($view->display_handler->handlers) && isset($view->display_handler->handlers['argument']) && count($view->display_handler->handlers['argument']));
     if ($path === FALSE && !$view_takes_arguments) {
-      // There is a path, but it does not match an active term.  In this case it is either
-      // an old alias, old term, or mistyped path, we will throw a 404.
+      // There is a path, but it does not match an active term. In this case it
+      // is either an old alias, old term, or mistyped path, we will throw a 404.
       drupal_not_found();
       exit;
     }
@@ -511,7 +511,7 @@ function theme_os_taxonomy_vocabulary_item_list($variables) {
           ->execute()
           ->fetchAssoc();
 
-        // Remove the purl from the alias.
+        // Remove the PURL from the alias.
         $term_alias = $result['alias'];
         $parts = explode('/', $term_alias);
         array_shift($parts);

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -90,49 +90,26 @@ function os_taxonomy_taxonomy_term_uri($term) {
  * Implements hook_views_query_alter().
  */
 function os_taxonomy_views_query_alter(&$view, &$query) {
-  if (!empty($_GET['tid']) && !empty($_GET['vocab'])) {
+  if (!$path = os_taxonomy_in_taxonomy_term_context($view)) {
 
-    if (!$relation = og_vocab_relation_get($_GET['vocab'])) {
-      throw new Exception(t('There is not vocab with the given ID @id', array('@id' => $_GET['vocab'])));
+    //If this view takes arguments we can't be sure that this is a 404, we will let the view decide.
+    $view_takes_arguments = (isset($view->display_handler->handlers) && isset($view->display_handler->handlers['argument']) && count($view->display_handler->handlers['argument']));
+    if ($path === FALSE && !$view_takes_arguments) {
+      // There is a path, but it does not match an active term.  In this case it is either
+      // an old alias, old term, or mistyped path, we will throw a 404.
+      drupal_not_found();
+      exit;
     }
 
-    if (!$vsite = vsite_get_vsite()) {
-      return;
-    }
-
-    if ($vsite->id != $relation->gid) {
-      return;
-    }
-
-    // The tid exists in the query string.
-    if (!$term = taxonomy_term_load($_GET['tid'])) {
-      return;
-    }
-
-    $tid = $term->tid;
-  }
-  else {
-    if (!$path = os_taxonomy_in_taxonomy_term_context($view)) {
-
-      //If this view takes arguments we can't be sure that this is a 404, we will let the view decide.
-      $view_takes_arguments = (isset($view->display_handler->handlers) && isset($view->display_handler->handlers['argument']) && count($view->display_handler->handlers['argument']));
-      if ($path === FALSE && !$view_takes_arguments) {
-        // There is a path, but it does not match an active term.  In this case it is either
-        // an old alias, old term, or mistyped path, we will throw a 404.
-        drupal_not_found();
-        exit;
-      }
-
-      // No extra path filter was found.
-      return;
-    }
-
-    $tid = str_replace('taxonomy/term/', '', $path);
+    // No extra path filter was found.
+    return;
   }
 
   $group_key = key($query->where);
   $alias = $query->add_table('field_data_og_vocabulary');
   $query->set_distinct();
+
+  $tid = str_replace('taxonomy/term/', '', $path);
   $query->add_where($group_key, "$alias.og_vocabulary_target_id", $tid, '=');
 
   if ($view_title = $view->get_title()) {
@@ -525,17 +502,27 @@ function theme_os_taxonomy_vocabulary_item_list($variables) {
         $link_options['attributes']['class'][] = 'active';
       }
 
-      $link_options['query'] = array(
-        'tid' => $tid,
-        'vocab' => $term->vid,
-      );
-
       // Handle events.
-      if (current($options['bundles']) == 'past_event') {
-        $term_path['path'] = 'calendar/past_events';
-      }
-      elseif (in_array(current($options['bundles']), array('upcoming_event', 'event'))) {
-        $term_path['path'] = 'calendar/upcoming';
+      if (strpos(current($options['bundles']), 'event') !== FALSE) {
+        // Get the term alias.
+        $result = db_select('url_alias')
+          ->fields('url_alias', array('alias'))
+          ->condition('source', 'taxonomy/term/' . $tid)
+          ->execute()
+          ->fetchAssoc();
+
+        // Remove the purl from the alias.
+        $term_alias = $result['alias'];
+        $parts = explode('/', $term_alias);
+        array_shift($parts);
+        $term_alias = implode('/', $parts);
+
+        if (current($options['bundles']) == 'past_event') {
+          $term_path['path'] = 'calendar/past_events/' . $term_alias;
+        }
+        elseif (in_array(current($options['bundles']), array('upcoming_event', 'event'))) {
+          $term_path['path'] = 'calendar/upcoming/' . $term_alias;
+        }
       }
 
       // Data contain data for term children.


### PR DESCRIPTION
#7228 

We now use the vocabulary name and term name for the links in the taxonomy widget and avoiding the need for the VID and TID in the url:
![selection_108](https://cloud.githubusercontent.com/assets/4497748/8052433/2d4f3864-0eba-11e5-981f-e3e51ee8945c.png)

