### PR TITLE
Fix "all" option not working for the LOF widget.

### DIFF
--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -424,27 +424,37 @@ abstract class os_boxes_default extends boxes_box {
   /**
    * Get the associated bundles for an App type.
    *
-   * @param $app_type
+   * @param string $app_type
    *  The App type to get the bundles for. Can be OS_PRIVATE_APP to get the
    *  private bundles or OS_PUBLIC_APP to get the public bundles. If empty, get
    *  all the bundles.
    *
+   * @param string $entity_type
+   *  Type of the entity for which to get bundles for.
+   *
    * @return array
    *  An array keyed by the app type and valued with the matching bundles.
    */
-  protected function getBundles($app_type = '') {
-    switch ($app_type) {
-      case OS_PRIVATE_APP:
-        $bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
-        break;
-      case OS_PUBLIC_APP:
-        $bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
-        break;
-      default:
-        $bundles['public_bundles'] = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
-        $bundles['private_bundles'] = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
-        break;
+  protected function getBundles($app_type = '', $entity_type = 'node') {
+    if ($entity_type == 'node') {
+      switch ($app_type) {
+        case OS_PRIVATE_APP:
+          $bundles = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+          break;
+        case OS_PUBLIC_APP:
+          $bundles = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+          break;
+        default:
+          $bundles['public_bundles'] = array_keys(os_get_bundles(array(OS_PUBLIC_APP)));
+          $bundles['private_bundles'] = array_keys(os_get_bundles(array(OS_PRIVATE_APP)));
+          break;
+      }
     }
+    elseif ($entity_type == 'file') {
+      $file_bundles = os_files_get_bundles();
+      $bundles = array_keys($file_bundles);
+    }
+
     return $bundles;
   }
 }

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_default.inc
@@ -451,8 +451,23 @@ abstract class os_boxes_default extends boxes_box {
       }
     }
     elseif ($entity_type == 'file') {
-      $file_bundles = os_files_get_bundles();
-      $bundles = array_keys($file_bundles);
+      switch ($app_type) {
+        case OS_PRIVATE_APP:
+          $bundles = array();
+          break;
+        case OS_PUBLIC_APP:
+          $file_bundles = os_files_get_bundles();
+          $bundles = array_keys($file_bundles);
+          break;
+        default:
+          $file_bundles = os_files_get_bundles();
+          $bundles['public_bundles'] = array_keys($file_bundles);
+          $bundles['private_bundles'] = array();
+          break;
+      }
+    }
+    else {
+      $bundles = array();
     }
 
     return $bundles;

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -372,8 +372,10 @@ class os_sv_list extends os_boxes_default {
     }
     else {
       // When "All" is selected show only public bundles.
-      $bundles = $this->getBundles(OS_PUBLIC_APP);
-      $query->propertyCondition('type', $bundles, 'IN');
+      if ($this->entity_type != 'file') {
+        $bundles = $this->getBundles(OS_PUBLIC_APP);
+        $query->propertyCondition('type', $bundles, 'IN');
+      }
     }
 
     // Pager.

--- a/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
+++ b/openscholar/modules/os/modules/os_sv_list/plugins/os_sv_list.inc
@@ -372,10 +372,8 @@ class os_sv_list extends os_boxes_default {
     }
     else {
       // When "All" is selected show only public bundles.
-      if ($this->entity_type != 'file') {
-        $bundles = $this->getBundles(OS_PUBLIC_APP);
-        $query->propertyCondition('type', $bundles, 'IN');
-      }
+      $bundles = $this->getBundles(OS_PUBLIC_APP, $this->entity_type);
+      $query->propertyCondition('type', $bundles, 'IN');
     }
 
     // Pager.


### PR DESCRIPTION
#7211 

This PR adds a check to see if when selecting "All" in the LOP, we display files. If we do, we skip the condition of adding only public bundles:
![selection_111](https://cloud.githubusercontent.com/assets/4497748/8054838/27488ba0-0ece-11e5-95ca-5b8a5a335dbd.png)

When using "All" we get all types of files (in the image-a text file and images).