### PR TITLE
Fix redirect after logging out.

### DIFF
--- a/openscholar/behat/features/misc/logout.feature
+++ b/openscholar/behat/features/misc/logout.feature
@@ -1,0 +1,10 @@
+Feature:
+  Testing the logout link.
+
+  @api @misc_first
+  Scenario: Verify that when logging out the user gets redirected to the page
+            he were in.
+    Given I am logging in as "john"
+     When I visit "john/classes"
+      And I click "Log out"
+     Then I should verify i am at "john/classes"

--- a/openscholar/modules/cp/modules/cp_toolbar/cp_toolbar.module
+++ b/openscholar/modules/cp/modules/cp_toolbar/cp_toolbar.module
@@ -73,7 +73,6 @@ function cp_toolbar_view() {
         'title' => t('Log out'),
         'href' => 'user/logout',
         'description' => t('Log out of this site'),
-        'query' => drupal_get_destination()
       ),
     );
     if (arg(0) == 'user') {


### PR DESCRIPTION
#7263 

This PR fixes the redirect after a logged user logs out from the site. The user was redirected to the site-wide page of the feature. He is now redirected to the correct page.

Before:
![selection_162](https://cloud.githubusercontent.com/assets/4497748/8326958/726658ea-1a97-11e5-8d79-265be0f04ef1.png)

After:
![selection_163](https://cloud.githubusercontent.com/assets/4497748/8326962/75da0832-1a97-11e5-8151-1d7dd257bc82.png)
