### PR TITLE
Fix not being able to create a content type through the UI.

### DIFF
--- a/openscholar/behat/features/javscript/page.feature
+++ b/openscholar/behat/features/javscript/page.feature
@@ -1,7 +1,7 @@
 Feature:
   Testing JS for the page edit.
 
-  @javascript @now
+  @javascript
   Scenario: Verify the page path is not changed after editing.
     Given I am logging in as "admin"
       And I visit "john/node/add/page"

--- a/openscholar/behat/features/misc/content_type_create.feature
+++ b/openscholar/behat/features/misc/content_type_create.feature
@@ -1,0 +1,11 @@
+Feature:
+  Testing node type creating.
+
+  @api @misc_first @now
+  Scenario: Verify we can create node type.
+    Given I am logging in as "admin"
+      And I visit "admin/structure/types/add"
+     When I fill in "Name" with "Foo"
+     When I fill in "Machine-readable name" with "foo"
+      And I press "Save content type"
+     Then I should see "The content type Foo has been added."

--- a/openscholar/drupal-org.make
+++ b/openscholar/drupal-org.make
@@ -38,6 +38,7 @@ projects[colorbox][version] = 2.5
 projects[comment_sources][subdir] = "contrib"
 projects[comment_sources][version] = 2.0
 projects[comment_sources][patch][] = "https://drupal.org/files/issues/22086870-comment-source-wrong-query-field-1.patch"
+projects[comment_sources][patch][] = "https://drupal.org/files/issues/change-submit-handler-index-2513794-2.patch"
 
 projects[context][subdir] = "contrib"
 projects[context][version] = 3.0-beta4


### PR DESCRIPTION
#7202 

Changed the index in the form for the comment_sources submit handler. This seems to love this.