### PR TITLE
Fix the duplication of importing rss feeds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ mysql:
   encoding: utf8
 
 env:
-  - TEST_SUITE=features_first
+#  - TEST_SUITE=features_first
   - TEST_SUITE=features_second
-  - TEST_SUITE=harvard
+#  - TEST_SUITE=harvard
 #  - TEST_SUITE=javscript
-  - TEST_SUITE=misc_first
-  - TEST_SUITE=misc_second
-  - TEST_SUITE=solr
-  - TEST_SUITE=taxonomy
-  - TEST_SUITE=vsite
-  - TEST_SUITE=widgets
+#  - TEST_SUITE=misc_first
+#  - TEST_SUITE=misc_second
+#  - TEST_SUITE=solr
+#  - TEST_SUITE=taxonomy
+#  - TEST_SUITE=vsite
+#  - TEST_SUITE=widgets
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ mysql:
   encoding: utf8
 
 env:
-#  - TEST_SUITE=features_first
+  - TEST_SUITE=features_first
   - TEST_SUITE=features_second
-#  - TEST_SUITE=harvard
-#  - TEST_SUITE=javscript
-#  - TEST_SUITE=misc_first
-#  - TEST_SUITE=misc_second
-#  - TEST_SUITE=solr
-#  - TEST_SUITE=taxonomy
-#  - TEST_SUITE=vsite
-#  - TEST_SUITE=widgets
+  - TEST_SUITE=harvard
+  - TEST_SUITE=javscript
+  - TEST_SUITE=misc_first
+  - TEST_SUITE=misc_second
+  - TEST_SUITE=solr
+  - TEST_SUITE=taxonomy
+  - TEST_SUITE=vsite
+  - TEST_SUITE=widgets
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/openscholar/behat/features/bootstrap/FeatureContext.php
+++ b/openscholar/behat/features/bootstrap/FeatureContext.php
@@ -1961,10 +1961,17 @@ class FeatureContext extends DrupalContext {
   public function iReImportFeedItem($node) {
     $nid = FeatureHelp::GetNodeId($node);
 
-    return array(
-      new Step\When('I visit "node/' . $nid . '/import"'),
-      new Step\When('I press "Import"'),
-    );
+    $source = feeds_source('os_reader', $nid);
+    try {
+      $source->import();
+    } catch (\Exception $e) {
+      
+    }
+
+//    return array(
+//      new Step\When('I visit "node/' . $nid . '/import"'),
+//      new Step\When('I press "Import"'),
+//    );
   }
 
   /**

--- a/openscholar/behat/features/bootstrap/FeatureContext.php
+++ b/openscholar/behat/features/bootstrap/FeatureContext.php
@@ -1965,13 +1965,8 @@ class FeatureContext extends DrupalContext {
     try {
       $source->import();
     } catch (\Exception $e) {
-      
-    }
 
-//    return array(
-//      new Step\When('I visit "node/' . $nid . '/import"'),
-//      new Step\When('I press "Import"'),
-//    );
+    }
   }
 
   /**

--- a/openscholar/behat/features/features/reader.feature
+++ b/openscholar/behat/features/features/reader.feature
@@ -85,3 +85,5 @@ Feature:
     Given I am logging in as "admin"
      When I re import feed item "John news importer"
      Then I verify the feed item "JFK was murdered" exists only "1" time for "john"
+      And I re import feed item "John news importer"
+     Then I verify the feed item "JFK was murdered" exists only "1" time for "john"

--- a/openscholar/behat/features/features/reader.feature
+++ b/openscholar/behat/features/features/reader.feature
@@ -80,7 +80,7 @@ Feature:
      When I visit "obama/cp/os-importer/news/manage"
      Then I should see "JFK was murdered"
 
-  @api @features_second
+  @js @features_second
   Scenario: Verify a feed item can be imported only once to the site.
     Given I am logging in as "admin"
      When I re import feed item "John news importer"

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -53,7 +53,7 @@ class OsFeedReaderFetcher extends FeedsProcessor {
       'importer_type' => $node_wrapper->getBundle() == 'blog_import' ? 'blog' : 'news',
     );
 
-    $feed_item = os_reader_feed_item_create($values);
+    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
 
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -55,7 +55,6 @@ class OsFeedReaderFetcher extends FeedsProcessor {
 
     $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
 
-//    $feed_item = os_reader_feed_item_create($values);
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));
     $wrapper->save();

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -53,9 +53,9 @@ class OsFeedReaderFetcher extends FeedsProcessor {
       'importer_type' => $node_wrapper->getBundle() == 'blog_import' ? 'blog' : 'news',
     );
 
-//    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
+    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
 
-    $feed_item = os_reader_feed_item_create($values);
+//    $feed_item = os_reader_feed_item_create($values);
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));
     $wrapper->save();

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -53,8 +53,7 @@ class OsFeedReaderFetcher extends FeedsProcessor {
       'importer_type' => $node_wrapper->getBundle() == 'blog_import' ? 'blog' : 'news',
     );
 
-//    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
-    $feed_item = os_reader_feed_item_create($values);
+    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
 
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -53,7 +53,8 @@ class OsFeedReaderFetcher extends FeedsProcessor {
       'importer_type' => $node_wrapper->getBundle() == 'blog_import' ? 'blog' : 'news',
     );
 
-    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
+//    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
+    $feed_item = os_reader_feed_item_create($values);
 
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));

--- a/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
+++ b/openscholar/modules/os_features/os_reader/plugins/OsFeedReaderFetcher.inc
@@ -53,8 +53,9 @@ class OsFeedReaderFetcher extends FeedsProcessor {
       'importer_type' => $node_wrapper->getBundle() == 'blog_import' ? 'blog' : 'news',
     );
 
-    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
+//    $feed_item = empty($entity->id) ? os_reader_feed_item_create($values) : os_reader_feed_item_load($entity->id);
 
+    $feed_item = os_reader_feed_item_create($values);
     $wrapper = entity_metadata_wrapper('os_feed_item', $feed_item);
     $wrapper->{OG_AUDIENCE_FIELD}->set($node_wrapper->{OG_AUDIENCE_FIELD}->value(array('identifier' => TRUE)));
     $wrapper->save();


### PR DESCRIPTION
#7379

The feeds worked as it should be - updating existing entries. The problem was in the that i didn't checked if the entity we handling is new or not and then copies were created. I need to see how this didn't failed the tests.

I still need to check why or write better tests for this but this is ready for review.