### PR TITLE
7982 - Media Browser: Bad formatting when the file name is long

### DIFF
--- a/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
+++ b/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
@@ -20,6 +20,7 @@
 .field-widget-media-draggable-file .file-list-single {
     border-bottom: 1px solid #ccc;
     padding: 5px 0;
+    word-wrap: break-word;
 }
 .field-widget-media-draggable-file .file-list-single .tabledrag-handle {
     display: inline-block;

--- a/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
+++ b/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
@@ -29,7 +29,11 @@
 }
 .field-widget-media-draggable-file .file-list-single span {
     display: inline-block;
-    width: 55%;
+    width: 60%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
 }
 .field-widget-media-draggable-file .file-list-single ul {
     display: inline-block;

--- a/openscholar/modules/frontend/media_browser/templates/field.html
+++ b/openscholar/modules/frontend/media_browser/templates/field.html
@@ -13,8 +13,8 @@
     <div class="file-list-single form-wrapper" ng-repeat="file in selectedFiles" ng-class="{even: $even, odd: $odd, highlight: file.highlight}">
         <input type="hidden" name="{{field_name}}[und][{{$index}}][fid]" value="{{file.id}}">
         <a href="#" class="tabledrag-handle" title="Drag to re-order" ng-show="selectedFiles.length > 1"><div class="handle">&nbsp;</div></a>
-        <span>
-            <img class="file-icon" alt="Icon for {{file.mime}}" title="{{file.mime}}" src="{{file.icon}}">
+        <span title="{{file.label}}">
+            <img class="file-icon" alt="Icon for {{file.mime}}" title="{{file.label}}" src="{{file.icon}}">
             {{file.label}} ({{file.filename}})
         </span>
         <ul>


### PR DESCRIPTION
Use word-wrap CSS attribute to ensure edit/delete controls are not superimposed
on filename

#7982 