### PR TITLE
7982 - Media Browser: Bad formatting when the file name is long #8009

### DIFF
--- a/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
+++ b/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
@@ -29,13 +29,18 @@
 }
 .field-widget-media-draggable-file div {
     white-space: nowrap;
+    overflow: hidden;
 }
 .field-widget-media-draggable-file .file-list-single span {
     display: inline-block;
     width: 60%;
+
+    /* Prevent Edit/Replace/Remove controls from wrapping */
     white-space: nowrap;
-    overflow: hidden;
+
+    /* Truncate long filenames with "..." */
     text-overflow: ellipsis;
+    overflow: hidden;
     -o-text-overflow: ellipsis;
 }
 .field-widget-media-draggable-file .file-list-single ul {
@@ -43,10 +48,18 @@
     width: 34%;
     margin: 0;
 }
+
 .field-widget-media-draggable-file .file-list-single ul li {
     display: inline-block;
     width: 32%;
     text-align: center;
+    white-space: nowrap;
+}
+
+/* Do not ellipsi-fy the edit/replace/remove control links */
+.field-widget-media-draggable-file .file-list-single ul li span {
+    text-overflow: visible;
+    overflow: visible;
 }
 .droppable-message,
 .droppable-standard-upload span {

--- a/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
+++ b/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
@@ -27,6 +27,9 @@
     position: relative;
     top: -5px;
 }
+.field-widget-media-draggable-file .file-list-single div {
+    white-space: nowrap;
+}
 .field-widget-media-draggable-file .file-list-single span {
     display: inline-block;
     width: 60%;

--- a/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
+++ b/openscholar/modules/custom/media_draggable/css/media_draggable.widget.css
@@ -27,7 +27,7 @@
     position: relative;
     top: -5px;
 }
-.field-widget-media-draggable-file .file-list-single div {
+.field-widget-media-draggable-file div {
     white-space: nowrap;
 }
 .field-widget-media-draggable-file .file-list-single span {


### PR DESCRIPTION
#7982 Ensure replace/edit/remove controls do not wrap (use CSS `white-space: nowrap`)