### PR TITLE
fix: expression always true

### DIFF
--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_twitterfeed/os_boxes_twitterfeed.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_twitterfeed/os_boxes_twitterfeed.inc
@@ -129,7 +129,7 @@ class os_boxes_twitterfeed extends os_boxes_default {
       $num_items = $this->options['num_items'];
       $followme_link = $this->options['followme_link'];
 
-      if ($twitkey[0] != '@' || $twitkey[0] != '#') {
+      if ($twitkey[0] != '@' && $twitkey[0] != '#') {
         switch($this->options['twitter_type']) {
           case 'user':
             $twitkey = '@' . $twitkey;


### PR DESCRIPTION
Expression
`($twitkey[0] != '@' || $twitkey[0] != '#')`
is always true.

1. if $twitkey[0]  is '@' then ($twitkey[0] != '#') is true -> whole expression is true 
2. if $twitkey[0]  is '#' then ($twitkey[0] != '@') is true -> whole expression is true 
3. if $twitkey[0]  is 'some_other_symbol' then ($twitkey[0] != '@') is true -> whole expression is true 


This possible defect found by [Static code analyzer AppСhecker](cnpo.ru/en/solutions/appchecker.php)