### PR TITLE
Added patch to drupal-org.make that allows oembed module to install

### DIFF
--- a/openscholar/drupal-org.make
+++ b/openscholar/drupal-org.make
@@ -274,6 +274,7 @@ projects[oembed][version] = 1.0-rc2
 projects[oembed][patch][] = "http://cgit.drupalcode.org/oembed/patch/?id=a27adf7c1afe763ee5f386f30f0aea73a6097ff1"
 projects[oembed][patch][] = "http://drupal.org/files/issues/oembed.2134415.wysiwyg_dimensions.patch"
 projects[oembed][patch][] = "https://raw.githubusercontent.com/openscholar/openscholar/514d6c636dc69ea76ea307a874c7cd9c3e0fb045/patches/oembed.alt_tags_no_escape.patch"
+projects[oembed][patch][] = "https://www.drupal.org/files/oembed-2021015-1.patch"
 
 projects[og][subdir] = "contrib"
 projects[og][version] = 2.6


### PR DESCRIPTION
I'm installing OpenScholar on Scientific Linux 6.7 with PHP 5.3.3 and encountered the following error from the oembed module during install:

Fatal error: Unsupported operand types in oembed.module on line 129

The patch in the following issue addresses this problem and allows the installation to continue:

Drupal Issue:	https://www.drupal.org/node/2021015#comment-8465945
Patch:		https://www.drupal.org/files/oembed-2021015-1.patch

Thanks,
Pablo