### PR TITLE
Problem in os_image_gallery.module for PHP versions < 5.4

### DIFF
--- a/openscholar/modules/os_features/os_image_gallery/os_image_gallery.module
+++ b/openscholar/modules/os_features/os_image_gallery/os_image_gallery.module
@@ -57,7 +57,7 @@ function os_image_gallery_menu_alter(&$items) {
  */
 function os_image_gallery_menu_local_tasks_alter(&$tasks, $item, $path) {
   if ($path == 'media-gallery/detail/%/%/remove') {
-    $tasks['tabs'] = [];
+    $tasks['tabs'] = array();
     return;
   }
 }


### PR DESCRIPTION
I'm installing OS on Scientific Linux 6 with PHP 5.3.3 and encountered the following error from os_image_gallery.module during the installation:

Parse error: syntax error, unexpected '[' in os_image_gallery.module on line 60

The line in question is:

$tasks['tabs'] = [];

This fails with a syntax error in PHP versions < 5.4 since the short array syntax is only available as of PHP 5.4. I've corrected by modifying this to the following:

$tasks['tabs'] = array();

Thanks,
Pablo