### PR TITLE
8562 - "Read More" link listed twice for News items #

### DIFF
--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -598,6 +598,8 @@ function os_process_node(&$vars) {
   // Only proceeds if we have a "Read more" link.
   if (!isset($vars['content']['links']['node']['#links']['node-readmore'])) {
     return;
+  } else {
+    $vars['content']['links']['node']['#links']['node-readmore']['attributes']['class'][] = 'node-readmore';
   }
 
   // Hides the "Read more" link if there is no body value.

--- a/openscholar/modules/os_features/os_blog/os_blog.module
+++ b/openscholar/modules/os_features/os_blog/os_blog.module
@@ -64,6 +64,12 @@ function os_blog_process_node(&$vars) {
   $pubdate = format_date($vars['created'], 'custom', 'F j, Y');
   // Publication date, formatted with time element
   $vars['submitted'] = '<time datetime="' . $vars['datetime'] . '" pubdate="pubdate">' . $pubdate . '</time>';
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_booklets/os_booklets.module
+++ b/openscholar/modules/os_features/os_booklets/os_booklets.module
@@ -306,3 +306,15 @@ function os_booklets_os_add_new_links_alter(&$links) {
     $links['book']['title'] = t('Booklet');
   }
 }
+
+
+/**
+ * Implements hook_process_hook() for node.
+ */
+function os_booklets_process_node(&$vars) {
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
+}

--- a/openscholar/modules/os_features/os_classes/os_classes.module
+++ b/openscholar/modules/os_features/os_classes/os_classes.module
@@ -210,6 +210,12 @@ function os_classes_process_node(&$vars) {
   if (isset($vars['content']['os_classes_entity_view_1'])) {
     unset($vars['content']['os_classes_entity_view_1']);
   }
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_events/os_events.module
+++ b/openscholar/modules/os_features/os_events/os_events.module
@@ -543,6 +543,12 @@ function os_events_process_node(&$variables) {
     ));
     $variables['content']['field_date'][0]['#markup'] = str_replace($rule, '', $variables['content']['field_date'][0]['#markup'] );
   }
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_faq/os_faq.module
+++ b/openscholar/modules/os_features/os_faq/os_faq.module
@@ -151,3 +151,14 @@ function os_faq_views_query_alter(&$view, &$query) {
     $query->orderby[1]['direction'] = variable_get('faq_order', 'DESC');
   }
 }
+
+/**
+ * Implements hook_process_hook() for node.
+ */
+function os_faq_process_node(&$vars) {
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
+}

--- a/openscholar/modules/os_features/os_links/os_links.module
+++ b/openscholar/modules/os_features/os_links/os_links.module
@@ -75,6 +75,12 @@ function os_links_process_node(&$vars) {
     'fragment' => isset($items[0]['fragment']) ? $items[0]['fragment'] : NULL
     )
   );
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_news/os_news.module
+++ b/openscholar/modules/os_features/os_news/os_news.module
@@ -135,6 +135,12 @@ function os_news_process_node(&$vars) {
       'data' => drupal_get_path('module', 'os_news') . '/os_news.css',
     ),
   );
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_reader/os_reader.module
+++ b/openscholar/modules/os_features/os_reader/os_reader.module
@@ -609,6 +609,12 @@ function os_reader_process_node(&$variables) {
 
     drupal_goto($type, array('fragment' => 'overlay=' . $url));
   }
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/modules/os_features/os_software/os_software.module
+++ b/openscholar/modules/os_features/os_software/os_software.module
@@ -215,6 +215,12 @@ function os_software_process_node(&$vars) {
       $vars['content'] = array_intersect_key($vars['content'], array('links' => TRUE));
       break;
   }
+
+  // If the readmore link has already been inserted inline into the body,
+  // remove it from the render array, so it's not printed twice
+  if (preg_match("/\bnode-readmore\b/", $vars['content']['body'][0]['#markup'])) {
+    unset($vars['content']['links']['node']['#links']['node-readmore']);
+  }
 }
 
 /**

--- a/openscholar/themes/hwpi_basetheme/css/hwpi.base.css
+++ b/openscholar/themes/hwpi_basetheme/css/hwpi.base.css
@@ -776,6 +776,7 @@ h2.comment-title.comment-form {
 }
 a.node-readmore {
     text-decoration: underline;
+    font-size: 13px;
 }
 /* Files tables, for attached files to nodes such as PDF's */
 


### PR DESCRIPTION
If the `readmore` link has already been inserted inline into the `body`,
remove it from the render array, so it's not printed twice