### PR TITLE
8596 - revert CSS selector in `os_sv_list_display`

### DIFF
--- a/openscholar/modules/os/modules/os_sv_list/os_sv_list_display.js
+++ b/openscholar/modules/os/modules/os_sv_list/os_sv_list_display.js
@@ -31,7 +31,7 @@
             delta = args.sv_list_box_delta;
         
         // After clicking on next/prev page ajax link, page will be slowly scrolled to the position where respective 'List of Post' widget markup starts.
-        $("html, body").animate({ scrollTop: $("#context-block-boxes-" + delta).offset().top }, "slow");
+        $("html, body").animate({ scrollTop: $("#block-boxes-" + delta).offset().top }, "slow");
 
         // if there's no page set in the query, assume its the first page
         if (typeof args.page == 'undefined') {


### PR DESCRIPTION
Fix *List of Posts* within *Tabs* widget.
  See http://community.openscholar.harvard.edu/openscholar/topics/list-of-posts-pager-not-working-within-tabs-widget?rfm=1