### PR TITLE
8754 - Add vsite_register_welcome_message #8754

### DIFF
--- a/openscholar/modules/vsite/vsite.install
+++ b/openscholar/modules/vsite/vsite.install
@@ -808,3 +808,11 @@ function vsite_update_7033(&$sandbox) {
     'path' => drupal_get_path('module', 'vsite') . '/updates/update7033.php',
   ));
 }
+
+/*
+ * This update will have no effect on production systems (since the var is already set there),
+ * but will add the Documentation link to left-hand Control Panel on scholar-demo.iq.harvard.edu
+*/
+function vsite_update_7034() {
+  variable_set('vsite_register_welcome_message', '57421');
+}


### PR DESCRIPTION
This update will have no effect on production systems (since the var is already set there),
but will add the "Documentation" link to the left-hand Control Panel on scholar-demo.iq.harvard.edu