### PR TITLE
8789 - fix logic error in validateDateFormats()

### DIFF
--- a/openscholar/modules/os/modules/os_importer/OsImporterEntityValidateBase.inc
+++ b/openscholar/modules/os/modules/os_importer/OsImporterEntityValidateBase.inc
@@ -96,17 +96,21 @@ class OsImporterEntityValidateBase extends EntityValidateBase {
    */
   protected function validateDateFormats($formats, $value, $field_name) {
     // Validate the date format for the start and end date.
+    $validationSuccess = false;
     foreach ($formats as $format) {
       if ($date = DateTime::createFromFormat($format, $value)) {
-        if ($date->format($format) != $value) {
-          $params = array(
-            '@date' => $value,
-            '@format' => date($format, $date->getTimestamp()),
-          );
-          $this->setError($field_name, 'The value of the date field (@date) is not valid. The date should be in a format similar to @format.', $params);
-          return;
+        if ($date->format($format) == $value) {
+          $validationSuccess = true;
         }
       }
+    }
+
+    if (! $validationSuccess) {
+      $params = array(
+          '@date' => $value,
+          '@format' => join(", ", $formats),
+      );
+      $this->setError($field_name, 'The value of the date field (@date) is not valid. The date should be in a format similar to one of the following formats: @format.', $params);
     }
 
     return TRUE;

--- a/openscholar/modules/os/modules/os_importer/os_importer.module
+++ b/openscholar/modules/os/modules/os_importer/os_importer.module
@@ -820,7 +820,7 @@ function os_importer_verify_uploaded_file($form, $form_state) {
         $orig_value_created = $value;
         $value = strtotime($value);
         // if strtotime() output is blank, then date format is not correct, displaying error message.
-        if(empty($value)) {
+        if(empty($value) || ($value < 0)) {
           form_set_error('created', t('Invalid date value entered for the field "!field" with value "!value".', array('!field' => $field, '!value' => $orig_value_created)));
         }
       }

--- a/openscholar/modules/os/modules/os_importer/plugins/validator/node/class/OsImporterClassValidator.class.php
+++ b/openscholar/modules/os/modules/os_importer/plugins/validator/node/class/OsImporterClassValidator.class.php
@@ -33,6 +33,8 @@ class OsImporterClassValidator extends OsImporterEntityValidateBase {
       return;
     }
 
+    $value = trim($value);
+
     $info = field_info_field($field_name_name);
 
     // Validate the semester.


### PR DESCRIPTION
Before this fix, it was possible for a malformed date to successfully validate, and then silently fail on the `db_insert()`.

 #8789