### PR TITLE
Add the file usage when syncing a profile.

### DIFF
--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -2662,6 +2662,8 @@ function os_field_display_node_alter(&$display, $context) {
  *  Determine if an exception need to be thrown when the copy of the file
  *  failed. When set to false the reason for the failure will return as a text
  *  in the returned array.
+ * @param $vsite
+ *   The vsite which the file belong to.
  *
  * @throws Exception
  *  Throwing an error when the copy of the file failed and the $exception set to
@@ -2670,7 +2672,8 @@ function os_field_display_node_alter(&$display, $context) {
  *  Return array of the file or error if occurred and the type of the return
  *  data(file/text).
  */
-function os_copy_file($url, $exception = FALSE, $show_error = TRUE) {
+function os_copy_file($url, $exception = FALSE, $show_error = TRUE, $vsite = NULL) {
+
   if (empty($url)) {
     return os_file_copy_set_error(t('You need to pass a url of the file.'), $exception, $show_error);
   }
@@ -2683,7 +2686,11 @@ function os_copy_file($url, $exception = FALSE, $show_error = TRUE) {
     return os_file_copy_set_error(t("The file directory is not wrietable. Please check her permission."), $exception, $show_error);
   }
 
-  if (!$file = system_retrieve_file($url, 'public://', TRUE)) {
+  if ($vsite) {
+    $vsite .= '/';
+  }
+
+  if (!$file = system_retrieve_file($url, 'public://' . $vsite, TRUE)) {
     return os_file_copy_set_error(t('An error occurred due unknown reason.'), $exception, $show_error);
   }
 

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -2686,11 +2686,18 @@ function os_copy_file($url, $exception = FALSE, $show_error = TRUE, $vsite = NUL
     return os_file_copy_set_error(t("The file directory is not wrietable. Please check her permission."), $exception, $show_error);
   }
 
-  if ($vsite) {
-    $vsite .= '/';
+  $path = 'public://';
+
+  if (!empty($vsite)) {
+    $path .= '/' . $vsite . '/files';
+
+    if (!file_exists(drupal_realpath($path))) {
+      // The directory does not exists. We need to create the directory.
+      drupal_mkdir(variable_get('file_public_path', 'sites/default/files') . '/' . $vsite . '/files', NULL, TRUE);
+    }
   }
 
-  if (!$file = system_retrieve_file($url, 'public://' . $vsite, TRUE)) {
+  if (!$file = system_retrieve_file($url, $path, TRUE)) {
     return os_file_copy_set_error(t('An error occurred due unknown reason.'), $exception, $show_error);
   }
 

--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -207,7 +207,9 @@ function os_profiles_init() {
 
         if ($identical_photos) {
           // Delete the file.
-          file_delete(file_load($copy_file['file']->fid));
+          if ($delete_file = file_load($copy_file['file']->fid)) {
+            file_delete($delete_file, TRUE);
+          }
         }
 
         if (!$identical_photos && $copy_file['type'] == 'file') {
@@ -839,7 +841,7 @@ function os_profiles_sync_profile_submit($form, $form_state) {
   // Retrieve the file from the original node.
   $file = NULL;
   if (!empty($file_url)) {
-    if (!$vsite) {
+    if (empty($vsite)) {
       $vsite = vsite_get_vsite();
     }
     $copy_file = os_copy_file($file_url, FALSE, FALSE, $vsite->group->purl);

--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -819,7 +819,10 @@ function os_profiles_sync_profile_submit($form, $form_state) {
   // Retrieve the file from the original node.
   $file = NULL;
   if (!empty($file_url)) {
-    $copy_file = os_copy_file($file_url, FALSE, FALSE);
+    if (!$vsite) {
+      $vsite = vsite_get_vsite();
+    }
+    $copy_file = os_copy_file($file_url, FALSE, FALSE, $vsite->group->purl);
 
     if ($copy_file['type'] == 'file') {
       $file = $copy_file['file'];

--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -157,6 +157,10 @@ function os_profiles_init() {
       continue;
     }
 
+    // Get the node person file ID.
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $original_photo = $wrapper->field_person_photo->value();
+
     $data = os_profiles_get_origin_node_values($node->field_original_destination_url[LANGUAGE_NONE][0]['value'], $fields);
 
     // Since using "put" will set NULL for missing fields we must send the original
@@ -186,11 +190,27 @@ function os_profiles_init() {
     if ($person_photo) {
       // If the file was updated within 2 min of the node then update it as
       // well.
+      $original_photo_dimension = image_get_info(drupal_realpath($original_photo['uri']));
+
       if (($changed - 120) < $person_photo['timestamp']) {
         $wrapper = entity_metadata_wrapper('node', $node);
         $copy_file = os_copy_file($person_photo['url'], FALSE, FALSE, $wrapper->{OG_AUDIENCE_FIELD}->get(0)->value()->purl);
 
-        if ($copy_file['type'] == 'file') {
+        $new_photo_dimension = image_get_info(drupal_realpath($copy_file['file']->uri));
+
+        $identical_photos = TRUE;
+        foreach (array_keys($new_photo_dimension) as $key) {
+          if ($new_photo_dimension[$key] != $original_photo_dimension[$key]) {
+            $identical_photos = FALSE;
+          }
+        }
+
+        if ($identical_photos) {
+          // Delete the file.
+          file_delete(file_load($copy_file['file']->fid));
+        }
+
+        if (!$identical_photos && $copy_file['type'] == 'file') {
           $file = $copy_file['file'];
         }
       }

--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -184,9 +184,11 @@ function os_profiles_init() {
     // We need to replace the file ID in the field with the new file ID we got.
     $file = NULL;
     if ($person_photo) {
-      // If the file was updated within 2 min of the node then update it as well.
+      // If the file was updated within 2 min of the node then update it as
+      // well.
       if (($changed - 120) < $person_photo['timestamp']) {
-        $copy_file = os_copy_file($person_photo['url'], FALSE, FALSE);
+        $wrapper = entity_metadata_wrapper('node', $node);
+        $copy_file = os_copy_file($person_photo['url'], FALSE, FALSE, $wrapper->{OG_AUDIENCE_FIELD}->get(0)->value()->purl);
 
         if ($copy_file['type'] == 'file') {
           $file = $copy_file['file'];
@@ -919,7 +921,7 @@ function os_profiles_insert_image($node, $file, $dimensions, $save = TRUE) {
 
   if ($save) {
     node_save($node);
-    file_usage_add($file, 'os_pofiles', 'node', $node->nid);
+    file_usage_add($file, 'os_profiles', 'node', $node->nid);
   }
 }
 

--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -919,6 +919,7 @@ function os_profiles_insert_image($node, $file, $dimensions, $save = TRUE) {
 
   if ($save) {
     node_save($node);
+    file_usage_add($file, 'os_pofiles', 'node', $node->nid);
   }
 }
 


### PR DESCRIPTION
#8787 

When a person synced to the site with an image there is no track what is the node that image belong to. This PR fixed it:
![public_files___john](https://cloud.githubusercontent.com/assets/1222368/17775142/92268fb0-655f-11e6-9250-e4a40b614754.jpg)

My question is do we need an update path?
