### PR TITLE
8865 - fix regular expression in os_events popover selector

### DIFF
--- a/openscholar/modules/os_features/os_events/js/os_events_popup.js
+++ b/openscholar/modules/os_features/os_events/js/os_events_popup.js
@@ -11,7 +11,7 @@
       $('.view-item-os_events .contents a').on('click', function(e) {
         e.preventDefault();
         var itemId = $(this).closest('div[data-item-id]').data('item-id');
-        var delta = $(this).attr("href").match(/delta=(\d)*/);
+        var delta = $(this).attr("href").match(/delta=(\d+)*/);
         var popOver = $('#event-popover-' + itemId + "-" + delta[1]);
         var isOpen = popOver.dialog("isOpen");
 


### PR DESCRIPTION
The current regex will not select on events when the delta is more than one
digit, thus breaking the popover functionality anytime a repeating event
exceeds 10 occurrences.