### PR TITLE
Fixed undefined index error from no IE JS added in theme settings

### DIFF
--- a/openscholar/themes/adaptivetheme/at_core/inc/load.inc
+++ b/openscholar/themes/adaptivetheme/at_core/inc/load.inc
@@ -593,7 +593,7 @@ function polly_wants_a_cracker($polly, $theme_name) {
             );
           }
         }
-        if ($crackers['ie']) {
+        if (isset($crackers['ie'])) {
           $baked_crackers = $crackers['ie'];
         }
       }


### PR DESCRIPTION
Clears up the following error:

"Notice: Undefined index: ie in polly_wants_a_cracker() (line 597 of /home/bryan/openscholar/profiles/openscholar/themes/adaptivetheme/at_core/inc/load.inc)."