### PR TITLE
Fixing the CSS path for the flavours assets in wysiwyg.

### DIFF
--- a/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.module
+++ b/openscholar/modules/os/modules/os_wysiwyg/os_wysiwyg.module
@@ -80,7 +80,7 @@ function os_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
 
     // Adding the css of the current flavor.
     foreach ($flavor_info['css'] as $css) {
-      $settings['contentsCss'][] = $base_url . '/' . $flavor_info['path'] . '/css/' . $css;
+      $settings['contentsCss'][] = $base_url . '/' . $flavor_info['path'] . '/' . $css;
     }
   }
 


### PR DESCRIPTION
#8936 

![first_blog___john_](https://cloud.githubusercontent.com/assets/1222368/19112956/35360a66-8b10-11e6-8cbc-2a82a0d4ed0b.jpg)
