### PR TITLE
9018 - ensure trailing slash on URLs #9018

### DIFF
--- a/openscholar/modules/os/modules/os_wysiwyg_link/os_wysiwyg_link.module
+++ b/openscholar/modules/os/modules/os_wysiwyg_link/os_wysiwyg_link.module
@@ -110,7 +110,7 @@ function os_wysiwyg_link_filter($text) {
         // set defaults so no notices appear
         if ($comps) {
           $comps += array('query' => '', 'fragment' => '');
-          $page = str_replace(array('?'.$comps['query'], '#'.$comps['fragment']), '', $m[3]);
+          $_page = str_replace(array('?'.$comps['query'], '#'.$comps['fragment']), '', $m[3]);
           // query string is in var=val&var=val format. parse it into an array for drupal
           parse_str(htmlspecialchars_decode($comps['query']), $query);
           $options = array(
@@ -119,8 +119,11 @@ function os_wysiwyg_link_filter($text) {
           );
         }
         else {
-          $page = $m[3];
+          $_page = $m[3];
         }
+
+        $page = _os_wysiwyg_fix_path($_page);
+
         if (url_is_external($page)) {
           $url = url($page, $options + array('external' => TRUE));
         }
@@ -148,4 +151,55 @@ function _os_wysiwyg_link_find_links($str) {
   $matches = array();
   preg_match_all('~<a[^>]+href="([^"]+)"[^>]+data-(fid|url)="([^"]*)">~', $str, $matches, PREG_SET_ORDER);
   return $matches;
+}
+
+/*
+ * Remove extra slashes, dots; add vsite
+ *
+ *  Source: http://www.geekality.net/2011/05/12/php-dealing-with-absolute-and-relative-urls/
+ */
+function _os_wysiwyg_fix_path($url) {
+    $base = base_path();
+    $space = spaces_get_space();
+
+    if ($space) {
+      $vsite = $space->group->purl;
+    }
+
+    // Return base if no url
+    if (! $url) {
+      return $base;
+    }
+
+    // Return if already absolute URL
+    if (parse_url($url, PHP_URL_SCHEME) != '') {
+      return $url;
+    }
+
+    // Urls only containing query or anchor
+    if ($url[0] == '#' || $url[0] == '?') {
+      return $base.$url;
+    }
+
+    // Parse base URL and convert to local variables: $path
+    extract(parse_url($base));
+
+    // If no path, use /
+    if ( ! isset($path)) $path = '/';
+
+    // Remove non-directory element from path
+    $path = preg_replace('#/[^/]*$#', '', $path);
+
+    // Destroy path if relative url points to root
+    if ($url[0] == '/') $path = '';
+
+    // Dirty absolute URL
+    $abs = "/$vsite/$url";
+
+    // Replace '//' or '/./' or '/foo/../' with '/'
+    $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');
+    for ($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {}
+
+    // Absolute URL is ready!
+    return $abs;
 }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -665,6 +665,8 @@ function os_process_node(&$vars) {
   // adds theme hook suggestion to load this template if it exists
   $vars['theme_hook_suggestions'][] = 'node__'.$vars['type'].'__'.$vars['view_mode'];
 
+  $vars['body'][0]['value'] = os_replace_relative_links_with_absolute_links($vars['body'][0]['value']);
+
   // Building "Read more" link for "No image teaser" for profiles
   if($vars['type'] == 'person' && $vars['content']['pic_bio']['body']['#view_mode'] == 'no_image_teaser') {
     $vars['content']['links']['node']['#links']['node-readmore'] = array(
@@ -3722,19 +3724,31 @@ function _os_make_absolute_link_callback($matches) {
  *  Source: http://www.geekality.net/2011/05/12/php-dealing-with-absolute-and-relative-urls/
  */
 function _os_make_absolute_link($url) {
-
     $base = base_path();
-    $host = $_SERVER[SERVER_NAME];
-    $scheme = $_SERVER[REQUEST_SCHEME];
+    $host = $_SERVER['SERVER_NAME'];
+    $scheme = $_SERVER['REQUEST_SCHEME'];
+    $space = spaces_get_space();
+
+    if ($space) {
+      $vsite = $space->group->purl;
+    }
+
+    if(! $scheme) $scheme = "https";
 
     // Return base if no url
-    if( ! $url) return $base;
+    if( ! $url) {
+      return $base;
+    }
 
     // Return if already absolute URL
-    if(parse_url($url, PHP_URL_SCHEME) != '') return $url;
+    if(parse_url($url, PHP_URL_SCHEME) != '') {
+      return $url;
+    }
 
     // Urls only containing query or anchor
-    if($url[0] == '#' || $url[0] == '?') return $base.$url;
+    if($url[0] == '#' || $url[0] == '?') {
+      return $base.$url;
+    }
 
     // Parse base URL and convert to local variables: $scheme, $host, $path
     extract(parse_url($base));
@@ -3749,7 +3763,7 @@ function _os_make_absolute_link($url) {
     if($url[0] == '/') $path = '';
 
     // Dirty absolute URL
-    $abs = "$host$path/$url";
+    $abs = "$host$path/$vsite/$url";
 
     // Replace '//' or '/./' or '/foo/../' with '/'
     $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3725,50 +3725,46 @@ function _os_make_absolute_link_callback($matches) {
  */
 function _os_make_absolute_link($url) {
     $base = base_path();
-    $host = $_SERVER['SERVER_NAME'];
-    $scheme = $_SERVER['REQUEST_SCHEME'];
     $space = spaces_get_space();
 
     if ($space) {
       $vsite = $space->group->purl;
     }
 
-    if(! $scheme) $scheme = "https";
-
     // Return base if no url
-    if( ! $url) {
+    if ( ! $url) {
       return $base;
     }
 
     // Return if already absolute URL
-    if(parse_url($url, PHP_URL_SCHEME) != '') {
+    if (parse_url($url, PHP_URL_SCHEME) != '') {
       return $url;
     }
 
     // Urls only containing query or anchor
-    if($url[0] == '#' || $url[0] == '?') {
+    if ($url[0] == '#' || $url[0] == '?') {
       return $base.$url;
     }
 
-    // Parse base URL and convert to local variables: $scheme, $host, $path
+    // Parse base URL and convert to local variables: $path
     extract(parse_url($base));
 
     // If no path, use /
-    if( ! isset($path)) $path = '/';
+    if ( ! isset($path)) $path = '/';
 
     // Remove non-directory element from path
     $path = preg_replace('#/[^/]*$#', '', $path);
 
     // Destroy path if relative url points to root
-    if($url[0] == '/') $path = '';
+    if ($url[0] == '/') $path = '';
 
     // Dirty absolute URL
-    $abs = "$host$path/$vsite/$url";
+    $abs = "/$vsite/$url";
 
     // Replace '//' or '/./' or '/foo/../' with '/'
     $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');
-    for($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {}
+    for ($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {}
 
     // Absolute URL is ready!
-    return $scheme.'://'.$abs;
+    return $abs;
 }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -665,8 +665,6 @@ function os_process_node(&$vars) {
   // adds theme hook suggestion to load this template if it exists
   $vars['theme_hook_suggestions'][] = 'node__'.$vars['type'].'__'.$vars['view_mode'];
 
-  $vars['body'][0]['value'] = os_replace_relative_links_with_absolute_links($vars['body'][0]['value']);
-
   // Building "Read more" link for "No image teaser" for profiles
   if($vars['type'] == 'person' && $vars['content']['pic_bio']['body']['#view_mode'] == 'no_image_teaser') {
     $vars['content']['links']['node']['#links']['node-readmore'] = array(
@@ -772,7 +770,6 @@ function os_preprocess_page(&$vars) {
   global $user;
 
   $markup = $vars['page']['content_top']['boxes_projects_get_started']['content']['#markup'];
-  $vars['page']['content_top']['boxes_projects_get_started']['content']['#markup'] = os_replace_relative_links_with_absolute_links($markup);
 
   // Session timeout checking will be only for logged in users.
   if ($user->uid) {
@@ -3702,69 +3699,4 @@ function os_preprocess_pager(&$variables, $hook) {
     $variables['tags'][3] = '»';
     $variables['tags'][4] = 'last';
   }
-}
-
-
-function os_replace_relative_links_with_absolute_links($content) {
-  $pattern = "/(<a [^>]*href\=\")([^\"]+)/im";
-  return preg_replace_callback($pattern, '_os_make_absolute_link_callback', $content);
-}
-
-function _os_make_absolute_link_callback($matches) {
-  if (sizeof($matches) == 3) {
-    return $matches[1] . _os_make_absolute_link($matches[2]);
-  } else {
-    error_log("_os_make_absolute_link_callback called without two matches.");
-  }
-}
-
-/*
- * Convert a relative link to an absolute link
- *
- *  Source: http://www.geekality.net/2011/05/12/php-dealing-with-absolute-and-relative-urls/
- */
-function _os_make_absolute_link($url) {
-    $base = base_path();
-    $space = spaces_get_space();
-
-    if ($space) {
-      $vsite = $space->group->purl;
-    }
-
-    // Return base if no url
-    if ( ! $url) {
-      return $base;
-    }
-
-    // Return if already absolute URL
-    if (parse_url($url, PHP_URL_SCHEME) != '') {
-      return $url;
-    }
-
-    // Urls only containing query or anchor
-    if ($url[0] == '#' || $url[0] == '?') {
-      return $base.$url;
-    }
-
-    // Parse base URL and convert to local variables: $path
-    extract(parse_url($base));
-
-    // If no path, use /
-    if ( ! isset($path)) $path = '/';
-
-    // Remove non-directory element from path
-    $path = preg_replace('#/[^/]*$#', '', $path);
-
-    // Destroy path if relative url points to root
-    if ($url[0] == '/') $path = '';
-
-    // Dirty absolute URL
-    $abs = "/$vsite/$url";
-
-    // Replace '//' or '/./' or '/foo/../' with '/'
-    $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');
-    for ($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {}
-
-    // Absolute URL is ready!
-    return $abs;
 }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -769,8 +769,6 @@ function _os_process_node_links_comment_add_class(&$vars) {
 function os_preprocess_page(&$vars) {
   global $user;
 
-  $markup = $vars['page']['content_top']['boxes_projects_get_started']['content']['#markup'];
-
   // Session timeout checking will be only for logged in users.
   if ($user->uid) {
     // Obtaining session lifetime value from php configuration.

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -768,13 +768,7 @@ function _os_process_node_links_comment_add_class(&$vars) {
  */
 function os_preprocess_page(&$vars) {
   global $user;
-
-  // Adding a trailing slash ensures the v-site name is included in relative links
-  $request_uri = $_SERVER['REQUEST_URI'];
-  if (strpos($request_uri, "/", strlen($request_uri) - 1) === FALSE) {
-    $_SERVER['REQUEST_URI'] .= "/";
-  }
-
+  
   // Session timeout checking will be only for logged in users.
   if ($user->uid) {
     // Obtaining session lifetime value from php configuration.

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -768,6 +768,13 @@ function _os_process_node_links_comment_add_class(&$vars) {
  */
 function os_preprocess_page(&$vars) {
   global $user;
+
+  // Adding a trailing slash ensures the v-site name is included in relative links
+  $request_uri = $_SERVER['REQUEST_URI'];
+  if (strpos($request_uri, "/", strlen($request_uri) - 1) === FALSE) {
+    $_SERVER['REQUEST_URI'] .= "/";
+  }
+
   // Session timeout checking will be only for logged in users.
   if ($user->uid) {
     // Obtaining session lifetime value from php configuration.

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -768,7 +768,10 @@ function _os_process_node_links_comment_add_class(&$vars) {
  */
 function os_preprocess_page(&$vars) {
   global $user;
-  
+
+  $markup = $vars['page']['content_top']['boxes_projects_get_started']['content']['#markup'];
+  $vars['page']['content_top']['boxes_projects_get_started']['content']['#markup'] = os_replace_relative_links_with_absolute_links($markup);
+
   // Session timeout checking will be only for logged in users.
   if ($user->uid) {
     // Obtaining session lifetime value from php configuration.
@@ -3697,4 +3700,59 @@ function os_preprocess_pager(&$variables, $hook) {
     $variables['tags'][3] = '»';
     $variables['tags'][4] = 'last';
   }
+}
+
+
+function os_replace_relative_links_with_absolute_links($content) {
+  $pattern = "/(<a [^>]*href\=\")([^\"]+)/im";
+  return preg_replace_callback($pattern, '_os_make_absolute_link_callback', $content);
+}
+
+function _os_make_absolute_link_callback($matches) {
+  if (sizeof($matches) == 3) {
+    return $matches[1] . _os_make_absolute_link($matches[2]);
+  } else {
+    error_log("_os_make_absolute_link_callback called without two matches.");
+  }
+}
+
+/*
+ * Convert an absolute link to a relative link
+ */
+function _os_make_absolute_link($url) {
+
+    $base = base_path();
+    $host = $_SERVER[SERVER_NAME];
+    $scheme = $_SERVER[REQUEST_SCHEME];
+
+    // Return base if no url
+    if( ! $url) return $base;
+
+    // Return if already absolute URL
+    if(parse_url($url, PHP_URL_SCHEME) != '') return $url;
+
+    // Urls only containing query or anchor
+    if($url[0] == '#' || $url[0] == '?') return $base.$url;
+
+    // Parse base URL and convert to local variables: $scheme, $host, $path
+    extract(parse_url($base));
+
+    // If no path, use /
+    if( ! isset($path)) $path = '/';
+
+    // Remove non-directory element from path
+    $path = preg_replace('#/[^/]*$#', '', $path);
+
+    // Destroy path if relative url points to root
+    if($url[0] == '/') $path = '';
+
+    // Dirty absolute URL
+    $abs = "$host$path/$url";
+
+    // Replace '//' or '/./' or '/foo/../' with '/'
+    $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');
+    for($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {}
+
+    // Absolute URL is ready!
+    return $scheme.'://'.$abs;
 }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3717,7 +3717,9 @@ function _os_make_absolute_link_callback($matches) {
 }
 
 /*
- * Convert an absolute link to a relative link
+ * Convert a relative link to an absolute link
+ *
+ *  Source: http://www.geekality.net/2011/05/12/php-dealing-with-absolute-and-relative-urls/
  */
 function _os_make_absolute_link($url) {
 

--- a/openscholar/tests/openscholar.test
+++ b/openscholar/tests/openscholar.test
@@ -352,8 +352,120 @@ class OSMakeAbsoluteLinkTestCase extends DrupalWebTestCase {
 
     # test 2
     # $markup = '<a href="foo">A link</a>.';
+    # $ret = os_replace_relative_links_with_absolute_links($markup);
+    # print $ret;
+  }
 
-    $ret = os_replace_relative_links_with_absolute_links($markup);
+
+  public function testOsWysiwygLinkFilter() {
+
+    $vsite_names = array(null, "vsite_name");
+    $hostnames = array(null, "hostname");
+    $schemes = array(null, "http");
+
+    $data_urls = array(null,
+                  "foo",
+                  "/foo",
+                  "/foo/",
+                  "../foo/",
+                  "../../foo/",
+                  "/foo/..",
+                  "/foo/../bar",
+                  "/foo/../bar/",
+    );
+
+    # foreach ($vsite_names as $vsite_name) {
+    #   foreach ($hostnames as $hostname) {
+    #     foreach ($schemes as $scheme) {
+    #       foreach ($data_urls as $data_url) {
+    #         foreach ($data_urls as $href) {
+
+    #           $attr1 = "href=\"$href\"";
+    #           $attr2 = "data-url=\"$data_url\"";
+    #           $a = "<a $attr1 $attr2> some text <a $attr2 $attr1>";
+
+    #           $found_links = _os_wysiwyg_link_find_links($a);
+    #           print "\na: $a => found_links: " . var_export($found_links, true);
+    #         }
+    #       }
+    #     }
+    #   }
+    # }
+
+    # test 1
+    $markup = '
+      Some content.
+
+      <a href="foo">A link</a>.
+
+      More content.
+
+      <a other-attribute="moo" href="http://www.foo.com/">A second link</a>.
+      <a other-attribute="boo" href="the-quick-brown-fox">A rel link</a>.
+
+      Yet more content.
+
+      <a href="javascript:do_not_touch();">A third link</a>.
+
+      The quick brown fox.
+
+      <a href="/foo">A link</a>.
+
+      - jumped over the lazy dog.
+
+      <a href="google.com/foo">A link</a>.
+
+      <p><a href="../../blog">../../blog</a></p>
+      <p><a href="../../blog/">../../blog/</a></p>
+      <p><a href="../blog">../blog</a></p>
+      <p><a href="../blog/">../blog/</a></p>
+      <p><a href="blog">blog</a></p>
+      <p><a href="blog/">blog/</a></p>
+      <p><a href="/blog">/blog</a></p>
+      <p><a href="/blog/">/blog/</a></p>
+      <p><a href="./blog">./blog</a></p>
+      <p><a href="./blog/">./blog/</a></p>
+      <p><a href="http://absolute.com">http://absolute.com</a></p>
+      <p><a href="ftp://absolute.com">ftp://absolute.com</a></p>
+      <p><a href="gopher://absolute.com">gopher://absolute.com</a></p>
+      <p><a href="torrent://absolute.com">torrent://absolute.com</a></p>
+
+      <p><a href="../../blog" data-url="../../blog">../../blog</a></p>
+      <p><a href="../../blog/" data-url="../../blog/">../../blog/</a></p>
+      <p><a href="../blog" data-url="../blog">../blog</a></p>
+      <p><a href="../blog/" data-url="../blog/">../blog/</a></p>
+      <p><a href="blog" data-url="blog">blog</a></p>
+      <p><a href="blog/" data-url="blog/">blog/</a></p>
+      <p><a href="/blog" data-url="/blog">/blog</a></p>
+      <p><a href="/blog/" data-url="/blog/">/blog/</a></p>
+      <p><a href="./blog" data-url="./blog">./blog</a></p>
+      <p><a href="./blog/" data-url="./blog/">./blog/</a></p>
+      <p><a href="http://absolute.com" data-url="http://absolute.com">http://absolute.com</a></p>
+      <p><a href="ftp://absolute.com" data-url="ftp://absolute.com">ftp://absolute.com</a></p>
+      <p><a href="gopher://absolute.com" data-url="gopher://absolute.com">gopher://absolute.com</a></p>
+      <p><a href="torrent://absolute.com" data-url="torrent://absolute.com">torrent://absolute.com</a></p>
+
+
+      <p><a href="../../blog" data-fid="../../blog">../../blog</a></p>
+      <p><a href="../../blog/" data-fid="../../blog/">../../blog/</a></p>
+      <p><a href="../blog" data-fid="../blog">../blog</a></p>
+      <p><a href="../blog/" data-fid="../blog/">../blog/</a></p>
+      <p><a href="blog" data-fid="blog">blog</a></p>
+      <p><a href="blog/" data-fid="blog/">blog/</a></p>
+      <p><a href="/blog" data-fid="/blog">/blog</a></p>
+      <p><a href="/blog/" data-fid="/blog/">/blog/</a></p>
+      <p><a href="./blog" data-fid="./blog">./blog</a></p>
+      <p><a href="./blog/" data-fid="./blog/">./blog/</a></p>
+      <p><a href="http://absolute.com" data-fid="http://absolute.com">http://absolute.com</a></p>
+      <p><a href="ftp://absolute.com" data-fid="ftp://absolute.com">ftp://absolute.com</a></p>
+      <p><a href="gopher://absolute.com" data-fid="gopher://absolute.com">gopher://absolute.com</a></p>
+      <p><a href="torrent://absolute.com" data-fid="torrent://absolute.com">torrent://absolute.com</a></p>
+    ';
+
+    # test 2
+    # $markup = '<a href="foo">A link</a>.';
+
+    $ret = os_wysiwyg_link_filter($markup);
 
     print $ret;
   }

--- a/openscholar/tests/openscholar.test
+++ b/openscholar/tests/openscholar.test
@@ -249,3 +249,81 @@ class OSWebTestCase extends OSProfileTestCase {
     $this->assertTrue(TRUE);
   }
 }
+/**
+ *
+ */
+class OSMakeAbsoluteLinkTestCase extends DrupalWebTestCase {
+
+  public function getInfo() {
+    return array(
+      'name' => 'Test absolute-to-relative link convertor function',
+      'description' => 'Unit test make_absolute_link_link() function',
+      'group' => 'OpenScholar',
+    );
+  }
+
+  public function setUp() {
+    // $this->profile = 'openscholar';
+    parent::setUp();
+  }
+
+  public function testMakeAbsoluteLink() {
+
+    $vsite_names = array(null, "vsite_name");
+    $hostnames = array(null, "hostname");
+    $schemes = array(null, "http");
+    $urls = array(null,
+                  "foo",
+                  "/foo",
+                  "/foo/",
+                  "../foo/",
+                  "../../foo/",
+                  "/foo/..",
+                  "/foo/../bar",
+                  "/foo/../bar/",
+    );
+
+    foreach ($vsite_names as $vsite_name) {
+      foreach ($hostnames as $hostname) {
+        foreach ($schemes as $scheme) {
+          foreach ($urls as $url) {
+            $base = "$scheme://$hostname/$vsite_name";
+            $abs_url = os_make_absolute_link($url);
+            print "url: $url, base:$base ==> $abs_url\n";
+          }
+        }
+      }
+    }
+
+    # test 1
+    $markup = '
+      Some content.
+
+      <a href="foo">A link</a>.
+
+      More content.
+
+      <a other-attribute="moo" href="http://www.foo.com/">A second link</a>.
+
+      Yet more content.
+
+      <a href="javascript:do_not_touch();">A third link</a>.
+
+      The quick brown fox.
+
+      <a href="/foo">A link</a>.
+
+      - jumped over the lazy dog.
+
+      <a href="google.com/foo">A link</a>.
+    ';
+
+    # test 2
+    # $markup = '<a href="foo">A link</a>.';
+
+    $pattern = "/(<a [^>]*href\=\")([^\"]+)/im";
+    $markup = preg_replace_callback($pattern, 'os_make_absolute_link_callback', $markup);
+
+    print $markup;
+  }
+}

--- a/openscholar/tests/openscholar.test
+++ b/openscholar/tests/openscholar.test
@@ -288,7 +288,7 @@ class OSMakeAbsoluteLinkTestCase extends DrupalWebTestCase {
         foreach ($schemes as $scheme) {
           foreach ($urls as $url) {
             $base = "$scheme://$hostname/$vsite_name";
-            $abs_url = os_make_absolute_link($url);
+            $abs_url = _os_make_absolute_link($url);
             print "url: $url, base:$base ==> $abs_url\n";
           }
         }
@@ -304,6 +304,7 @@ class OSMakeAbsoluteLinkTestCase extends DrupalWebTestCase {
       More content.
 
       <a other-attribute="moo" href="http://www.foo.com/">A second link</a>.
+      <a other-attribute="boo" href="the-quick-brown-fox">A rel link</a>.
 
       Yet more content.
 
@@ -316,14 +317,44 @@ class OSMakeAbsoluteLinkTestCase extends DrupalWebTestCase {
       - jumped over the lazy dog.
 
       <a href="google.com/foo">A link</a>.
+
+      <p><a href="../../blog">../../blog</a></p>
+      <p><a href="../../blog/">../../blog/</a></p>
+      <p><a href="../blog">../blog</a></p>
+      <p><a href="../blog/">../blog/</a></p>
+      <p><a href="blog">blog</a></p>
+      <p><a href="blog/">blog/</a></p>
+      <p><a href="/blog">/blog</a></p>
+      <p><a href="/blog/">/blog/</a></p>
+      <p><a href="./blog">./blog</a></p>
+      <p><a href="./blog/">./blog/</a></p>
+      <p><a href="http://absolute.com">http://absolute.com</a></p>
+      <p><a href="ftp://absolute.com">ftp://absolute.com</a></p>
+      <p><a href="gopher://absolute.com">gopher://absolute.com</a></p>
+      <p><a href="torrent://absolute.com">torrent://absolute.com</a></p>
+
+
+      <p><a someOtherAttribute="what-if-there is junk here"  href="../../blog">../../blog</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="../../blog/">../../blog/</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="../blog">../blog</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="../blog/">../blog/</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="blog">blog</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="blog/">blog/</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="/blog">/blog</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="/blog/">/blog/</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="./blog">./blog</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="./blog/">./blog/</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="http://absolute.com">http://absolute.com</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="ftp://absolute.com">ftp://absolute.com</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="gopher://absolute.com">gopher://absolute.com</a></p>
+      <p><a someOtherAttribute="what-if-there is junk here"  href="torrent://absolute.com">torrent://absolute.com</a></p>
     ';
 
     # test 2
     # $markup = '<a href="foo">A link</a>.';
 
-    $pattern = "/(<a [^>]*href\=\")([^\"]+)/im";
-    $markup = preg_replace_callback($pattern, 'os_make_absolute_link_callback', $markup);
+    $ret = os_replace_relative_links_with_absolute_links($markup);
 
-    print $markup;
+    print $ret;
   }
 }


### PR DESCRIPTION
#9018 Adding the trailing slash makes relative links relative to the vsite level,
instead of the SERVER_NAME level.

Note: a link that was previously "dependant" on a URL *without* a trailing
slash will need to be pre-pended with a "../" to point to it's old target.
Alternatively, users needing a link relative to the vsite directory level,
could be required to prepend links with the vsite name.