### PR TITLE
9040 - Embedded Google calendars displaying incorrectly - again #9040

### DIFF
--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_tabs/os_boxes_tabs_display.js
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_tabs/os_boxes_tabs_display.js
@@ -29,8 +29,15 @@ Drupal.behaviors.os_boxes_tabs = { attach: function (ctx) {
   // When there is embeded media inside tabs widget, iframe src attribute needs to be reloaded for corresponding tab click event to render scrolbars.
   $('.ui-tabs-anchor').on("click", function( event, ui ) {
     var container_id = $(this).parent().attr('aria-controls');
-    // Trumba calendars have empty HTML codes in its iframe src on page load, so their content cannot be refreshed after clicking on tab.
-    $('#' + container_id + ' iframe:not([id^="trumba.spud"])').attr("src", $('#' + container_id + ' iframe').attr("src"));
+
+    var container_id_src = $('#' + container_id + ' iframe:not([id^="trumba.spud"])').attr("src");
+
+    // Do not refresh the src attribute for Google Calendar embeds (G Cal)
+    if (/www.google.com\/calendar/.exec(container_id_src) === null) {
+
+      // Trumba calendars have empty HTML codes in its iframe src on page load, so their content cannot be refreshed after clicking on tab.
+      $('#' + container_id + ' iframe:not([id^="trumba.spud"])').attr("src", $('#' + container_id + ' iframe').attr("src"));
+    }
   });
 
   function clickHandle(e) {


### PR DESCRIPTION
*Partially* re-applying [Sept_2016 hotfix for Calendar embed](https://github.com/openscholar/openscholar/commit/54a44d98906a90abfcdb376fbcd0d0aee27662d8) (without clobbering @digitalpiku's scrollbar fix in 17704b432d08f989acfc1d77aa3df0243399a0a5).

#9040 