### PR TITLE
Fix javascript error when creating link in wysiwyg.

### DIFF
--- a/openscholar/modules/os/modules/os_wysiwyg_link/js/wysiwyg-os_link.js
+++ b/openscholar/modules/os/modules/os_wysiwyg_link/js/wysiwyg-os_link.js
@@ -108,7 +108,7 @@ Drupal.wysiwyg.plugins['os_link'] = {
       }
 
     }
-    Drupal.media.popups.mediaBrowserOld(function (insert) {
+    Drupal.media.popups.mediaBrowser(function (insert) {
       self.insertLink();
     }, settings['global'], {}, {
       src: Drupal.settings.osWysiwygLink.browserUrl, // because media is dumb about its query args


### PR DESCRIPTION
creating a pull request for #8576.  I confirm that I have the same problems as @mazz44 and removing Old fixes the problem