### PR TITLE
Display the original name of the file when viewing the detail page

### DIFF
--- a/openscholar/modules/os_features/os_image_gallery/os_image_gallery.module
+++ b/openscholar/modules/os_features/os_image_gallery/os_image_gallery.module
@@ -90,6 +90,7 @@ function os_image_gallery_menu_alter(&$items) {
   // The media gallery path when removing an image from the gallery.
   $menu_path = 'media-gallery/detail/%media_gallery_mg_node/%media_gallery_mg_item/remove';
   $items[$menu_path]['theme callback'] = 'cp_theme_name';
+  $items['media-gallery/detail/%media_gallery_mg_node/%media_gallery_mg_item']['page callback'] = 'os_image_gallery_media_gallery_detail_page';
 }
 
 /**
@@ -523,4 +524,18 @@ function os_image_gallery_image_optimize($image, $dst) {
 
   watchdog('os_image_gallery', t('The image @name has been compressed.', $params));
   return TRUE;
+}
+
+/**
+ * Overriding the page callback for displaying a single image item.
+ */
+function os_image_gallery_media_gallery_detail_page($gallery_node, $file) {
+  $content = media_gallery_detail_page($gallery_node, $file);
+
+  // The original function "Replace non letters or numbers with a single space"
+  // and much more which remove special characters and a white space. Setting
+  // the default file name is what we would like to display in that case.
+  drupal_set_title($file->filename);
+
+  return $content;
 }


### PR DESCRIPTION
#9201:
Without the fix:
![books_and_scholars_accoutrements_ch_aekk_ri___john](https://cloud.githubusercontent.com/assets/1222368/22418858/8110099e-e6e3-11e6-9d20-a0e54bb6df54.png)

With the fix:
![books_and_scholars__accoutrements__ch aekkori____john](https://cloud.githubusercontent.com/assets/1222368/22418876/918e44fc-e6e3-11e6-9c4e-a05d185be0a6.png)
