### PR TITLE
Permission string 'administer content' doesn't exist.

### DIFF
--- a/openscholar/modules/os/modules/os_front/os_front.module
+++ b/openscholar/modules/os/modules/os_front/os_front.module
@@ -89,11 +89,11 @@ function os_front_block_view($delta) {
             '#suffix' => '</span>',
             'text-anon' => array(
               '#markup' => variable_get('os_front_site_title', 'Change Me'),
-              '#access' => !user_access('administer content'),
+              '#access' => !user_access('administer nodes'),
             ),
             'text-auth' => array(
               '#markup' => l(variable_get('os_front_site_title', 'Change Me'), 'admin/config/openscholar/site-title'),
-              '#access' => user_access('administer content'),
+              '#access' => user_access('administer nodes'),
             )
           )
         ),

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -51,7 +51,7 @@ function os_menu() {
     'weight' => -5,
     'page callback' => 'drupal_get_form',
     'page arguments' => array('os_settings_form'),
-    'access arguments' => array('administer content'),
+    'access arguments' => array('administer nodes'),
   );
 
   $items['admin/config/openscholar/frontend'] = array(
@@ -59,7 +59,7 @@ function os_menu() {
     'description' => 'Edit settings that affect general front end performance',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('os_settings_frontend_form'),
-    'access arguments' => array('administer content'),
+    'access arguments' => array('administer nodes'),
   );
 
   $items['page_not_found'] = array(


### PR DESCRIPTION
Though it shows up in the admin permissions UI as "administer content", in the backend it's actually 'administer nodes'.  OS and OS Front modules mistakenly use "administer content".  Pull request rectifies that.

To reproduce issue:
Attempt to configure Open Scholar settings at /admin/config as a fully-privileged, non-UID 1 user.  "OPENSCHOLAR SETTINGS" block doesn't render. 

---
Submitted on behalf of Faculty Websites project using OpenScholar at Arizona State University.