### PR TITLE
as like DRUSH, use variable to invoke bower cmd

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -117,6 +117,6 @@ CUR_DIR=$(pwd)
 # Get the angualr components.
 (
   cd $BUILD_ROOT/openscholar
-  bower install
+  $BOWER install
   cd -
 )


### PR DESCRIPTION
as Drush is invoked via $DRUSH, let's apply the same for bower invocation, it gives the possibility to use local overrides as far as i see.