### PR TITLE
import.sh:  sanitization improvement

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -39,8 +39,10 @@ drush vset file_public_path "sites/default/files"
 drush vset file_private_path ""
 drush vset file_temporary_path "/tmp"
 
+# Make sure admin is not blocked
+drush sqlq "UPDATE users SET status=1 WHERE uid=1;"
+drush sqlq "DELETE FROM flood;"
+
 # Open site as admin.
 drush uli --uri=$2
-
-
 


### PR DESCRIPTION
It could happen that the to-be-imported DB has a blocked admin user (attempts to login by bots, etc).
In this case, drush uli any login attempts fail.
Let's go one step further in the DB sanitization for local use and make sure admin is not blocked (and purge flood table as well).