### PR TITLE
as Drupal core is lower than 7.50, it makes sense to apply an already…

### DIFF
--- a/openscholar/drupal-org-core.make
+++ b/openscholar/drupal-org-core.make
@@ -9,3 +9,4 @@ projects[drupal][patch][] = "https://drupal.org/files/drupal.menu-theme-objects.
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/drupal-7.41-transactional-cache.patch"
 projects[drupal][patch][] = "https://raw.githubusercontent.com/openscholar/openscholar/72f579693cf4a3410081692e72697f693d7542cc/patches/drupal-7-43.file_managed_unique_id.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/entity-array_flip_warning-1102570-95.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/drupal-1081266-189-avoid-rescanning-missing-module-D7.patch"


### PR DESCRIPTION
… in-core patch to dramatically speed up the sites that are not upgraded to 7.50+ for any reasons