### PR TITLE
os_restful: do not try to keep track of deleted entities with non-numeric identifier

### DIFF
--- a/openscholar/modules/os/modules/os_restful/os_restful.module
+++ b/openscholar/modules/os/modules/os_restful/os_restful.module
@@ -222,7 +222,7 @@ function os_restful_entity_delete($entity, $type) {
   $wrapper = entity_metadata_wrapper($type, $entity);
   $id = $wrapper->getIdentifier();
 
-  if ($id !== FALSE) {
+  if ($id !== FALSE && is_numeric($id)) {
     $extra = module_invoke_all('os_restful_entity_delete_data', $type, $entity);
     drupal_alter('os_restful_entity_delete_data', $extra);
 


### PR DESCRIPTION
It results in a DB Exception Discovered actual scenario: feature reverts at OS upgrade from older version. The string ID from `$wrapper->getIdentifier();` was `os_create_node`