### PR TITLE
vsite: allow local devel node inspection

### DIFF
--- a/openscholar/modules/vsite/plugins/vsite.inc
+++ b/openscholar/modules/vsite/plugins/vsite.inc
@@ -127,6 +127,11 @@ class vsite extends space_og {
                 'absolute' => TRUE,
                 'query' => drupal_get_query_parameters(),
               ));
+
+            // Allow local devel debugging on the node.
+            if (module_exists('devel') && arg(2) == 'devel') {
+              break;
+            }
             // Goto vsite's home <front> page
             if ($current_url != rtrim($space->get_absolute_url(), "/")) {
               purl_goto("<front>", array(


### PR DESCRIPTION
Right now it's impossible for developers to use quasi standard way to inspect a vsite node via `node/XX/devel`. Let's make an exception. Maybe we should be even more permissive, i am happy to relax even more (generic way) if it makes sense.