### PR TITLE
Make the build process pluggable

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -15,6 +15,17 @@ OPTIONS:
 EOF
 }
 
+# Includes all the shell scripts from a certain directory.
+scriptdir()
+{
+  for f in $1/*; do
+    if [[ -x $f ]]
+    then
+      . $f
+    fi
+  done
+}
+
 DOCROOT="www"
 OPSDIR=
 while getopts ":hd:o:" OPTION
@@ -41,6 +52,9 @@ done
 # Move to the top directory.
 ROOT="$(dirname $0)/.."
 cd $ROOT
+
+# Invoke project-specific post-build script.
+scriptdir "$(dirname $0)/pre-build"
 
 # Chores.
 (
@@ -120,3 +134,6 @@ CUR_DIR=$(pwd)
   $BOWER install
   cd -
 )
+
+# Invoke project-specific post-build script.
+scriptdir "$(dirname $0)/post-build"

--- a/scripts/post-build/README.md
+++ b/scripts/post-build/README.md
@@ -1,0 +1,1 @@
+You may commit executable Bash scripts to this directory for project-specific postprocessing of the builds.

--- a/scripts/pre-build/README.md
+++ b/scripts/pre-build/README.md
@@ -1,0 +1,1 @@
+You may commit executable Bash scripts to this directory for project-specific preprocessing of the builds.


### PR DESCRIPTION
Right now if there's a need to do project-specific extra steps of the build, it's not possible to do in an update-proof way, if you hack it into your openscholar instance, it will break at the next upgrade. With this patch, it would be possible to invoke extra steps, before and after the build process, we can think of it like adding hooks to a module