### PR TITLE
9332 - "Add menu item" contextual link hangs

### DIFF
--- a/openscholar/modules/cp/modules/cp_menu/cp_menu.module
+++ b/openscholar/modules/cp/modules/cp_menu/cp_menu.module
@@ -202,7 +202,7 @@ function cp_menu_contextual_links_view_alter(&$element, $items) {
 	        $menu = $link[1];
 
 	        if (in_array($menu, $menus)) {
-	          $element['#links']['menu-add'] = array('title' => t('Add menu item'), 'href' => $fragment . $menu, 'attributes' => array('class' => array('ctools-use-modal')));
+	          $element['#links']['menu-add'] = array('title' => t('Add menu item'), 'href' => $fragment . $menu);
 	        }
 	      }
 	    }


### PR DESCRIPTION
remove `ctools-use-modal` CSS attribute.
`overlay=vsite-name/cp/build/menu/link/new/primary-menu` link
functions without it.

 #9332