### PR TITLE
9361 - update parent menus with no children

### DIFF
--- a/openscholar/modules/os/os.install
+++ b/openscholar/modules/os/os.install
@@ -914,3 +914,43 @@ function os_update_7046() {
   module_enable(array('ap_settings_form', 'restful_message'));
   return t('Enhanced settings forms enabled.');
 }
+
+/**
+ * Update has_children field of parent menus having 0 children
+ */
+function os_update_7047() {
+
+  # Find menus with children
+  $r1 = db_select('menu_links', 'ml')
+    ->fields('ml', array('mlid'))
+    ->condition('has_children', 0, '>')
+    ->execute();
+
+  $count = 0;
+  foreach ($r1 as $record) {
+
+    # Find child menus whose parents we found above
+    $r2 = db_select('menu_links', 'ml')
+      ->fields('ml', array('mlid'))
+      ->condition('plid', $record->mlid)
+      ->execute()
+      ->rowCount();
+
+    # If the parent menu does not - in fact - have children,
+    # update the has_children field to 0
+    if ($r2 == 0) {
+
+      $r3 = db_update('menu_links')
+        ->fields(array('has_children' => 0))
+        ->condition('mlid', $record->mlid)
+        ->execute();
+
+      if ($r3) {
+        $count++;
+      }
+    }
+  }
+
+  $message = t('@count parent menus with no children links have been updated.', array('@count' => $count));
+  drupal_set_message($message);
+}

--- a/openscholar/modules/os/os.install
+++ b/openscholar/modules/os/os.install
@@ -920,34 +920,21 @@ function os_update_7046() {
  */
 function os_update_7047() {
 
-  # Find menus with children
-  $r1 = db_select('menu_links', 'ml')
-    ->fields('ml', array('mlid'))
-    ->condition('has_children', 0, '>')
-    ->execute();
+  # Select menus labeled as parents, but for which no menus reference as parents
+  $childless_parent_menus = db_query('SELECT mlid FROM menu_links m ' .
+      'WHERE (has_children > 0) AND ' .
+      '(NOT EXISTS (SELECT * FROM menu_links m2 WHERE m.mlid = m2.plid))');
 
-  $count = 0;
-  foreach ($r1 as $record) {
+  foreach ($childless_parent_menus as $childless_parent_menu) {
 
-    # Find child menus whose parents we found above
-    $r2 = db_select('menu_links', 'ml')
-      ->fields('ml', array('mlid'))
-      ->condition('plid', $record->mlid)
-      ->execute()
-      ->rowCount();
+    # Update the childless parent menus to not have children
+    $db_update_result = db_update('menu_links')
+      ->fields(array('has_children' => 0))
+      ->condition('mlid', $childless_parent_menu->mlid)
+      ->execute();
 
-    # If the parent menu does not - in fact - have children,
-    # update the has_children field to 0
-    if ($r2 == 0) {
-
-      $r3 = db_update('menu_links')
-        ->fields(array('has_children' => 0))
-        ->condition('mlid', $record->mlid)
-        ->execute();
-
-      if ($r3) {
-        $count++;
-      }
+    if ($db_update_result) {
+      $count++;
     }
   }
 

--- a/openscholar/modules/os/os.install
+++ b/openscholar/modules/os/os.install
@@ -920,24 +920,17 @@ function os_update_7046() {
  */
 function os_update_7047() {
 
-  # Select menus labeled as parents, but for which no menus reference as parents
   $childless_parent_menus = db_query('SELECT mlid FROM menu_links m ' .
       'WHERE (has_children > 0) AND ' .
       '(NOT EXISTS (SELECT * FROM menu_links m2 WHERE m.mlid = m2.plid))');
 
-  foreach ($childless_parent_menus as $childless_parent_menu) {
+  $mlids = array_keys($childless_parent_menus->fetchAllKeyed());
 
-    # Update the childless parent menus to not have children
-    $db_update_result = db_update('menu_links')
-      ->fields(array('has_children' => 0))
-      ->condition('mlid', $childless_parent_menu->mlid)
-      ->execute();
+  $db_update_result = db_update('menu_links')
+    ->fields(array('has_children' => 0))
+    ->condition('mlid', $mlids, 'IN')
+    ->execute();
 
-    if ($db_update_result) {
-      $count++;
-    }
-  }
-
-  $message = t('@count parent menus with no children links have been updated.', array('@count' => $count));
+  $message = t('@count parent menus with no children links have been updated.', array('@count' => sizeof($mlids)));
   drupal_set_message($message);
 }


### PR DESCRIPTION
There appear to be about 75 menu's with a has_children value of 1,
but no children.  Could this be an issue with `menu_delete_links`?

This update sets the `has_children` field to 0, when no children menu's
are found.

 #9361