### PR TITLE
9371 - rework the "add taxonomy term" form

### DIFF
--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -1894,6 +1894,7 @@ function os_taxonomy_form_taxonomy_form_term_alter(&$form, &$form_state, $form_i
   unset($form['relations']['weight']);
   $form['relations']['parent']['#options'][0] = "Keep at top";
   $form['relations']['parent']['#multiple'] = false;
+  $form['relations']['parent']['#description'] = "Place the term in the name field under an existing term in the dropdown.";
 
   $form['parent'] = $form['relations']['parent'];
   unset($form['relations']);

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -1894,8 +1894,7 @@ function os_taxonomy_form_taxonomy_form_term_alter(&$form, &$form_state, $form_i
   unset($form['relations']['weight']);
   $form['relations']['parent']['#options'][0] = "<Top most level>";
   $form['relations']['parent']['#multiple'] = false;
-    $form['relations']['parent']['#description'] = "The above named term is positioned here in the vocabulary.";
-  $form['show_description'][LANGUAGE_NONE]['#description'] = "The above named term is positioned here in the vocabulary.";
+  $form['relations']['parent']['#description'] = "The above named term is positioned here in the vocabulary.";
 
   $form['parent'] = $form['relations']['parent'];
   unset($form['relations']);

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -1890,6 +1890,14 @@ function os_taxonomy_form_taxonomy_form_term_alter(&$form, &$form_state, $form_i
   );
   $form['#attached']['library'][] = array('media', 'media_browser');
   $form['#attached']['library'][] = array('os_common', 'FileEditorModal');
+
+  unset($form['relations']['weight']);
+  $form['relations']['parent']['#options'][0] = "<Top most level>";
+  $form['relations']['parent']['#multiple'] = false;
+  $form['show_description'][LANGUAGE_NONE]['#description'] = "The above named term is positioned here in the vocabulary.";
+
+  $form['parent'] = $form['relations']['parent'];
+  unset($form['relations']);
 }
 
 /**

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -1894,6 +1894,7 @@ function os_taxonomy_form_taxonomy_form_term_alter(&$form, &$form_state, $form_i
   unset($form['relations']['weight']);
   $form['relations']['parent']['#options'][0] = "<Top most level>";
   $form['relations']['parent']['#multiple'] = false;
+    $form['relations']['parent']['#description'] = "The above named term is positioned here in the vocabulary.";
   $form['show_description'][LANGUAGE_NONE]['#description'] = "The above named term is positioned here in the vocabulary.";
 
   $form['parent'] = $form['relations']['parent'];

--- a/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
+++ b/openscholar/modules/os/modules/os_taxonomy/os_taxonomy.module
@@ -1892,9 +1892,8 @@ function os_taxonomy_form_taxonomy_form_term_alter(&$form, &$form_state, $form_i
   $form['#attached']['library'][] = array('os_common', 'FileEditorModal');
 
   unset($form['relations']['weight']);
-  $form['relations']['parent']['#options'][0] = "<Top most level>";
+  $form['relations']['parent']['#options'][0] = "Keep at top";
   $form['relations']['parent']['#multiple'] = false;
-  $form['relations']['parent']['#description'] = "The above named term is positioned here in the vocabulary.";
 
   $form['parent'] = $form['relations']['parent'];
   unset($form['relations']);


### PR DESCRIPTION
 1. remove the weight field (its confusing and duplicates whats already found on a vocabulary term list page)
 1. Take the Parent terms field out of the collapse fieldset
 1. Relabel the field "The above named term is positioned here in the vocabulary"
 1. Convert the multiselect field to a single option select
 1. Rename root to "Top most level"

 #9371