### PR TITLE
9383 - Remove "Calendar" title from mini calendar

### DIFF
--- a/openscholar/modules/os_features/os_events/os_events.views_default.inc
+++ b/openscholar/modules/os_features/os_events/os_events.views_default.inc
@@ -119,7 +119,7 @@ function os_events_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'Calendar';
+  $handler->display->display_options['title'] = '';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['link_display'] = 'page_1';
   $handler->display->display_options['access']['type'] = 'spaces_feature';


### PR DESCRIPTION
Remove main "Calendar" heading from the mini calendar widget

 #9383