### PR TITLE
9403 - include "Link" in "Filtered search" options

### DIFF
--- a/openscholar/modules/os/modules/os_search_solr/plugins/os_search_solr_search_box/os_search_solr_search_box.inc
+++ b/openscholar/modules/os/modules/os_search_solr/plugins/os_search_solr_search_box/os_search_solr_search_box.inc
@@ -36,7 +36,7 @@ class os_search_solr_search_box extends os_boxes_default {
     $bundle = $this->options['bundle'];
     $bundles = os_get_bundles(array(OS_PUBLIC_APP, OS_PRIVATE_APP));
 
-    unset($bundles['feed'], $bundles['link']);
+    unset($bundles['feed']);
     unset($bundles['slideshow_slide'], $bundles['feed_importer']);
 
     $form['bundle'] = array(


### PR DESCRIPTION
Unsure why "Link" was deliberately excluded from "Filtered search" dropdown
menu, see below:

 https://github.com/openscholar/openscholar/issues/7697
 https://github.com/openscholar/openscholar/pull/7706
 https://github.com/openscholar/openscholar/commit/6cc6fd07639623b4a6efd1bc969f3263c6e4e2b2

 #9403