### PR TITLE
9421 - add email validation to Person type

### DIFF
--- a/openscholar/modules/os_features/os_profiles/os_profiles.module
+++ b/openscholar/modules/os_features/os_profiles/os_profiles.module
@@ -510,6 +510,18 @@ function os_profiles_form_person_node_form_alter(&$form, $form_state) {
       $info['#access'] = FALSE;
     }
   }
+
+  // Validate email address
+  $form['field_email'][LANGUAGE_NONE][0]['#element_validate'] = array('os_profiles_validate_mail');
+}
+
+/*
+ * Form element validator for email addresses
+ */
+function os_profiles_validate_mail($element) {
+  if (isset($element['value']['#value']) && !valid_email_address($element['value']['#value'])) {
+    form_error($element, t('The e-mail address %mail is not valid.', array('%mail' => $element['value']['#value'])));
+  }
 }
 
 /**


### PR DESCRIPTION
Uses PHP's built-in `FILTER_VALIDATE_EMAIL`.  See also:

 - http://php.net/manual/en/filter.constants.php
 - http://www.php.net/manual/en/filter.filters.validate.php
 - http://stackoverflow.com/a/19220270/712035

 #9421