### PR TITLE
Adding element invisible span when trimming the text.

### DIFF
--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3707,7 +3707,10 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
         }
         else {
           // No break tag but the original text is longer than the trimmed text.
-          if (strlen($item['value']) != strlen($text)) {
+          // In case we have a break tag, even in the trimmed text, we will not
+          // provide a read more link since another function will handle that
+          // for us.
+          if (strlen($item['value']) != strlen($text) && strpos($text, '<!--break-->') === FALSE) {
             $read_more($entity_type, $entity, $text);
           }
         }

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3686,19 +3686,30 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
 
       foreach ($items as $delta => $item) {
         $text = text_summary($item['value'], $item['format'], $display['settings']['trim_length']);
-        $delimiter = strpos($item['value'], '<!--break-->');
 
         // Remove the ellipsis we got from the text summary.
         if (strpos($text, '…') !== 0) {
           $text = str_replace('…', '', $text);
         }
 
-        // Check the if the text was trimmed and we don't have the break tag.
-        // The break tag will be handled in another place thus give us two
-        // 'Read more' links.
-        if (strlen($item['value']) != strlen($text) && $delimiter === FALSE) {
+        $read_more = function($entity_type, $entity, &$text) {
           $uri = entity_uri($entity_type, $entity);
           $text .= '… ' . l(t('Read more <span class="element-invisible"> about @title</span>', array('@title' => entity_label($entity_type, $entity))), $uri['path'], array('html' => true));
+        };
+
+        $delimiter = strpos($item['value'], '<!--break-->') !== FALSE && strpos($text, '<!--break-->') === FALSE;
+
+        if ($delimiter) {
+          // We have a break tag in the original value but the trimmed text
+          // function removed the break tag. In that case show the read more
+          // button.
+          $read_more($entity_type, $entity, $text);
+        }
+        else {
+          // No break tag but the original text is longer than the trimmed text.
+          if (strlen($item['value']) != strlen($text)) {
+            $read_more($entity_type, $entity, $text);
+          }
         }
 
         $element[$delta] = array('#markup' => '<div class="os-trim-text">' . $text . '</div>');

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3701,7 +3701,7 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
           $text .= '… ' . l(t('Read more <span class="element-invisible"> about @title</span>', array('@title' => entity_label($entity_type, $entity))), $uri['path'], array('html' => true));
         }
 
-        $element[$delta] = array('#markup' => $text);
+        $element[$delta] = array('#markup' => '<div class="os-trim-text">' . $text . '</div>');
       }
 
       break;

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3688,6 +3688,11 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
         $text = text_summary($item['value'], $item['format'], $display['settings']['trim_length']);
         $delimiter = strpos($item['value'], '<!--break-->');
 
+        // Remove the ellipsis we got from the text summary.
+        if (strpos($text, '…') !== 0) {
+          $text = str_replace('…', '', $text);
+        }
+
         // Check the if the text was trimmed and we don't have the break tag.
         // The break tag will be handled in another place thus give us two
         // 'Read more' links.

--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3693,7 +3693,7 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
         // 'Read more' links.
         if (strlen($item['value']) != strlen($text) && $delimiter === FALSE) {
           $uri = entity_uri($entity_type, $entity);
-          $text .= '… ' . l(t('Read more'), $uri['path']);
+          $text .= '… ' . l(t('Read more <span class="element-invisible"> about @title</span>', array('@title' => entity_label($entity_type, $entity))), $uri['path'], array('html' => true));
         }
 
         $element[$delta] = array('#markup' => $text);

--- a/openscholar/themes/os_basetheme/css/global.pages.css
+++ b/openscholar/themes/os_basetheme/css/global.pages.css
@@ -1216,3 +1216,7 @@ LIST OF POSTS - PERSON TEASER IN SIDEBAR
 .block-element {
     display: block;
 }
+
+.os-trim-text p {
+    display: inline;
+}


### PR DESCRIPTION
#9432

I can't find a way to reproduce the double ellipsis(three dots thingy) - is there a way to give me the link?

But I fixed the element invisible:
![galleries___john](https://cloud.githubusercontent.com/assets/1222368/24503947/e903219c-155c-11e7-9f0a-ab2a06c1d1ad.png)
