### PR TITLE
os_importer.module: added the ability to skip term import for Feeds

### DIFF
--- a/openscholar/modules/os/modules/os_importer/os_importer.module
+++ b/openscholar/modules/os/modules/os_importer/os_importer.module
@@ -982,7 +982,8 @@ function os_importer_feeds_presave(FeedsSource $source, $entity, $item) {
   }
 
   // Only import vocabularies, if not disallowed explicitly.
-  if (empty($source->importer()->getConfig()['skip_vocabularies'])) {
+  $importer_config = $source->importer()->getConfig();
+  if (empty($importer_config['skip_vocabularies'])) {
     _os_importer_import_vocab($source, $entity, $item, $id);
   }
 

--- a/openscholar/modules/os/modules/os_importer/os_importer.module
+++ b/openscholar/modules/os/modules/os_importer/os_importer.module
@@ -982,7 +982,7 @@ function os_importer_feeds_presave(FeedsSource $source, $entity, $item) {
   }
 
   // Only import vocabularies, if not disallowed explicitly.
-  if (empty($feed->skip_vocabularies)) {
+  if (empty($source->skip_vocabularies)) {
     _os_importer_import_vocab($source, $entity, $item, $id);
   }
 

--- a/openscholar/modules/os/modules/os_importer/os_importer.module
+++ b/openscholar/modules/os/modules/os_importer/os_importer.module
@@ -982,7 +982,7 @@ function os_importer_feeds_presave(FeedsSource $source, $entity, $item) {
   }
 
   // Only import vocabularies, if not disallowed explicitly.
-  if (empty($source->skip_vocabularies)) {
+  if (empty($source->importer()->getConfig()['skip_vocabularies'])) {
     _os_importer_import_vocab($source, $entity, $item, $id);
   }
 

--- a/openscholar/modules/os/modules/os_importer/os_importer.module
+++ b/openscholar/modules/os/modules/os_importer/os_importer.module
@@ -981,7 +981,11 @@ function os_importer_feeds_presave(FeedsSource $source, $entity, $item) {
     $entity->field_offered_year = array();
   }
 
-  _os_importer_import_vocab($source, $entity, $item, $id);
+  // Only import vocabularies, if not disallowed explicitly.
+  if (empty($feed->skip_vocabularies)) {
+    _os_importer_import_vocab($source, $entity, $item, $id);
+  }
+
   _os_importer_import_behalf_of_user($source, $entity, $item, $id);
 }
 


### PR DESCRIPTION
A valid use-case:
refactoring ICS support to retrieve events from URL, upgraded various modules for the purpose and it broke the term import process. This would allow to bypass the process on a per-feed basis.