### PR TITLE
Fix file upload regex to handle ports in URL

### DIFF
--- a/openscholar/modules/frontend/os_common/FileEditor/FileEditor.module.js
+++ b/openscholar/modules/frontend/os_common/FileEditor/FileEditor.module.js
@@ -269,7 +269,7 @@
     // [a-zA-Z0-9.?#_-]+ matches against the filename without extension
     // ([a-zA-Z0-9]+) matches the extension itself
     // ($|[?#]) matches end of the string or a URL filename terminator (? or #)
-    var r = /^([a-z]+:\/\/[a-zA-Z0-9.\/_-:]+\/)?[a-zA-Z0-9.?#_ -]+\.([a-zA-Z0-9]+)($|[?#])/,
+    var r = /^([a-z]+:\/\/[a-zA-Z0-9.\/:_-]+\/)?[a-zA-Z0-9.?#_ -]+\.([a-zA-Z0-9]+)($|[?#])/,
       result = r.exec(url);
 
     if (result) {

--- a/openscholar/modules/frontend/os_common/FileEditor/FileEditor.module.js
+++ b/openscholar/modules/frontend/os_common/FileEditor/FileEditor.module.js
@@ -269,7 +269,7 @@
     // [a-zA-Z0-9.?#_-]+ matches against the filename without extension
     // ([a-zA-Z0-9]+) matches the extension itself
     // ($|[?#]) matches end of the string or a URL filename terminator (? or #)
-    var r = /^([a-z]+:\/\/[a-zA-Z0-9.\/_-]+\/)?[a-zA-Z0-9.?#_ -]+\.([a-zA-Z0-9]+)($|[?#])/,
+    var r = /^([a-z]+:\/\/[a-zA-Z0-9.\/_-:]+\/)?[a-zA-Z0-9.?#_ -]+\.([a-zA-Z0-9]+)($|[?#])/,
       result = r.exec(url);
 
     if (result) {


### PR DESCRIPTION
My local open scholar instance is running on a non standard port. The regex that detects file extensions for a file was not handling such URLs, making it impossible to do a replacement file upload (validation always failed because it couldn't detect the extension).