### PR TITLE
Ensure admin_panel and login query params are not added more than once

### DIFF
--- a/openscholar/modules/frontend/admin_panel/admin_panel.module
+++ b/openscholar/modules/frontend/admin_panel/admin_panel.module
@@ -230,6 +230,12 @@ function admin_panel_url_outbound_alter(&$path, &$options, $original) {
   if (!in_array($path, $always_open_pages) || empty($options['query']['destination']) || ($path == 'user' && $user->uid)) {
     return;
   }
+  
+  // Don't add query params to destination if they are already there.
+  if (strpos($options['query']['destination'], 'admin_panel') !== FALSE) {
+    return;
+  }
+  
   $queryparam_add = (strpos($options['query']['destination'], '?') ? '&' : '?').drupal_http_build_query(array("admin_panel" => 1, 'login' => 1));
   $options['query']['destination'] = $options['query']['destination'] . $queryparam_add;
 }


### PR DESCRIPTION
The admin_panel module alters login links and adds the "admin_panel" and "login" query string parameters to the destination parameter. Under certain circumstances (like with the CAS module), the destination path on a login link already has these two query string parameters on them, and this adds them twice. This actually causes CAS logins to break for paths that use the destination param.