### PR TITLE
Additional fix for vsite purl detection for base domains containing a port

### DIFF
--- a/openscholar/modules/vsite/modules/vsite_domain/plugins/purl_vsite_path.inc
+++ b/openscholar/modules/vsite/modules/vsite_domain/plugins/purl_vsite_path.inc
@@ -46,15 +46,17 @@ if (!class_exists('purl_vsite_path')) {
           }
 
           global $base_url;
-          // HTTP_HOST includes port, but we want to remove it to make our comparisons with purl_base_domain.
-          $http_hostname = explode(':', $_SERVER['HTTP_HOST'])[0];
 
-          $on_base_domain = preg_replace('~https?://~', '', $http_hostname) == parse_url(variable_get('purl_base_domain', $base_url),PHP_URL_HOST);
-          $clean_url = preg_replace('~https?://~', '', variable_get('purl_base_domain', $base_url));
-          $temp = explode('/', $clean_url);
+          // Remove the HTTP/S protocol and port number from the incoming HTTP
+          // host as well as the base domain. This allows us to compare the two
+          // without concern for those differences.
+          $stripped_http_hostname = $this->stripProtocolAndPortFromUrl($_SERVER['HTTP_HOST']);
+          $stripped_purl_base_domain = $this->stripProtocolAndPortFromUrl(variable_get('purl_base_domain', $base_url));
+
+          $on_base_domain = $stripped_http_hostname == parse_url(variable_get('purl_base_domain', $base_url),PHP_URL_HOST);
           $disabled_url = $space_found || in_array($settings->value, self::$disabled);
-          $custom_domain = strlen($vsite_domain) && preg_replace('~https?://~', '', $http_hostname) != $vsite_domain;
-          $host_url_match = !strlen($vsite_domain) && preg_replace('~https?://~', '', $http_hostname) != $temp[0];
+          $custom_domain = strlen($vsite_domain) && $stripped_http_hostname != $vsite_domain;
+          $host_url_match = !strlen($vsite_domain) && $stripped_http_hostname != $stripped_purl_base_domain;
           if ($disabled_url || $custom_domain || $host_url_match) {
             unset($parsed[$site]);
             if (!$space_found && $on_base_domain && strlen($vsite_domain) && count(explode('/', $q)) < 2) {
@@ -73,6 +75,22 @@ if (!class_exists('purl_vsite_path')) {
       }
 
       return $parsed;
+    }
+
+    /**
+     * Strips the HTTP/S protocol and port number off a URL.
+     *
+     * @param $url
+     *   The URL, like 'https://example.com:443'
+     *
+     * @return string
+     *   The URL without its HTTP/S protocol or a port.
+     */
+    private function stripProtocolAndPortFromUrl($url) {
+      $output = preg_replace('~https?://~', '', $url);
+      $output = explode(':', $output)[0];
+
+      return $output;
     }
 
     public function rewrite(&$path, &$options, $element) {


### PR DESCRIPTION
The check for `$host_url_match` was still not working right. This fixes that and cleans things up a bit so they are easier to understand and maintain.

See #9632 