### PR TITLE
fix news photo label so it only appears in the revisions context. #9742

### DIFF
--- a/openscholar/themes/cp_theme/css/cp_theme.css
+++ b/openscholar/themes/cp_theme/css/cp_theme.css
@@ -1778,7 +1778,7 @@ body.page-node-revisions .node {
   content: 'Attached files';
 }
 
-.node-news .photo .field-type-image:before {
+.page-node-revisions .node-news .photo .field-type-image:before {
   content:'News Photo';
 }
 


### PR DESCRIPTION
see https://github.com/openscholar/openscholar/issues/9742