### PR TITLE
Fixed php compatibility issue with versions < 5.5

### DIFF
--- a/openscholar/modules/os/os.module
+++ b/openscholar/modules/os/os.module
@@ -3736,7 +3736,9 @@ function os_field_formatter_view($entity_type, $entity, $field, $instance, $lang
             $text = str_replace('…', ' ', $text);
           }
           // Only display read more link if there is a content after break tag.
-          if (!empty(drupal_strlen($text_after_break))) {
+	  //php < 5.5 compatibility
+          $temp = drupal_strlen($text_after_break);
+          if (!empty($temp)) {
             $read_more($entity_type, $entity, $text);
           }
         }


### PR DESCRIPTION
This pull request is to address the issue described in: https://github.com/openscholar/openscholar/issues/9761

An error is generated when using the empty function (pretty common incompatibility from using PHP versions < 5.5 -- in our case 5.4.5).

PHP Fatal error: Can't use function return value in write context in /var/www/sites.cns.utexas.edu/profiles/openscholar/modules/os/os.module on line 3739

Defining a variable to perform the empty function on fixes this issue and as far as I can tell is the only glaring php version incompatibility for php version 5.4.5.

Request comes from College of Natural Sciences Web team at the University of Texas at Austin

-Ryan