### PR TITLE
Prevent cp_theme.css from overriding theme's link color

### DIFF
--- a/openscholar/themes/cp_theme/css/cp_theme.css
+++ b/openscholar/themes/cp_theme/css/cp_theme.css
@@ -31,8 +31,7 @@ body:not(.overlay) .node-form {
     padding: 2px 0;
 }
 
-.ui-widget-content a,
-a {
+.ui-widget-content a {
     color: #215990;
 }
 


### PR DESCRIPTION
The cp_theme.css file get's added at the end of all the CSS files, and as a result, the generic CSS definition that specifies the link color overwrites the generic CSS definition a theme may provide.

This fixes that by removing the generic link style for `a` from cp_theme.css. Not sure it is even needed, since there's already a more specific rule in place for `.ui-widget-content` which I think is all the cp module would be concerned with?