### PR TITLE
Fix broken site section dropdown selector in layout editor

### DIFF
--- a/openscholar/modules/cp/modules/cp_layout/cp_layout.form.inc
+++ b/openscholar/modules/cp/modules/cp_layout/cp_layout.form.inc
@@ -14,7 +14,7 @@ function cp_layout_full_form($form, $form_state){
 
   // Sort the site content alphabetically in the site section dropdown.
   $content = array_splice($contexts, 2);
-  sort($content);
+  asort($content);
   $contexts = array_merge($contexts, $content);
 
   $current = '';


### PR DESCRIPTION
The site section dropdown selector in the layout editor is broken. The values of the form element are numeric instead of the text machine name strings that they should be.

Current:
![screen shot 2018-01-16 at 11 24 16 am](https://user-images.githubusercontent.com/544886/34999555-01def6e4-fab0-11e7-9c71-d523ccee3dfa.png)

What it should be:
![screen shot 2018-01-16 at 11 24 38 am](https://user-images.githubusercontent.com/544886/34999560-0627dedc-fab0-11e7-965c-3a45c53ce7e3.png)

The fix is to use "asort" instead of "sort" when sorting the dropdown list elements. This preserves the associative array keys.

This bug was introduced in issue #10066 