### PR TITLE
#10254 add new og_task import content from CSV

### DIFF
--- a/openscholar/modules/vsite/modules/vsite_preset/includes/import_content.inc
+++ b/openscholar/modules/vsite/modules/vsite_preset/includes/import_content.inc
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @file
+ * Content import task functions.
+ */
+
+/**
+ * A generic task which attempts to import content from CSV.
+ */
+function vsite_preset_import_content_task($entity, $task, &$context) {
+  $vsite = vsite_get_vsite($entity->nid, TRUE);
+  if (!$vsite) {
+    return FALSE;
+  }
+  // Save the current space.
+  $current_space = spaces_get_space();
+  // Temporary switch the current space to created vsite.
+  spaces_set_space($vsite);
+
+  // Get default importable content types.
+  $default_types = os_importer_importable_content();
+  $types = [];
+
+  $preset = spaces_preset_load($entity->spaces_preset_og, 'og');
+  if (isset($preset->value['variable']['vsite_preset_import_content_types'])) {
+    // Load the desired content types from preset's variable.
+    $content_types = array_flip($preset->value['variable']['vsite_preset_import_content_types']);
+    $types = array_intersect_key($default_types, $content_types);
+  }
+  if (empty($types)) {
+    $types = $default_types;
+  }
+
+  $imported = vsite_preset_import_content($types, $preset);
+
+  // Switch back the current space.
+  spaces_set_space($current_space);
+
+  return $imported;
+}
+
+/**
+ * Attempts to import content of configured types from CSV files.
+ *
+ * @param array $types
+ *   List of content types to import.
+ * @param object $preset
+ *   Preset object.
+ *
+ * @return bool $imported
+ *   Whether or not the vsite's content was imported.
+ */
+function vsite_preset_import_content($types, $preset) {
+  $imported = FALSE;
+  $path = drupal_get_path('module', $preset->export_module);
+  foreach ($types as $type => $importer_info) {
+    $file = $path . '/preset_assets/' . $preset->name . '/content/' . $type . '.csv';
+    if (file_exists($file) && is_readable($file) && isset($importer_info['csv'])) {
+      $source = feeds_source($importer_info['csv']);
+      if ($source) {
+        // Load the source fetcher config.
+        $fetcher_config = $source->getConfigFor($source->importer->fetcher);
+        // Add the new source file to the fetcher config.
+        $fetcher_config['source'] = $file;
+        $source->setConfigFor($source->importer->fetcher, $fetcher_config);
+        // Explicitly set process in background.
+        $config = array('process_in_background' => TRUE);
+        $source->importer->addConfig($config);
+        // Save the source.
+        $source->save();
+        // Execute the import.
+        $source->startImport();
+        $imported = TRUE;
+      }
+    }
+  }
+  return $imported;
+}

--- a/openscholar/modules/vsite/modules/vsite_preset/vsite_preset.module
+++ b/openscholar/modules/vsite/modules/vsite_preset/vsite_preset.module
@@ -56,6 +56,15 @@ function vsite_preset_og_tasks_info($entity_type, $entity) {
   );
   $tasks['vsite_preset_menu_order'] = new vsite_task($properties);
 
+  $properties = array(
+    'title' => t('Import content from CSV'),
+    'description' => t('Import vsite content from CSV files.'),
+    'required' => FALSE,
+    'callback' => 'vsite_preset_import_content_task',
+    'file' => $path . '/includes/import_content.inc',
+  );
+  $tasks['vsite_preset_import_content'] = new vsite_task($properties);
+
   return $tasks;
 }
 


### PR DESCRIPTION
In order to import content from CSV files on creating new Vsite:
1. Add new task "'vsite_preset_import_content" to "og_tasks" section of desired spaces preset.
2. Optionally add variable "vsite_preset_import_content_types" to "variable" section of desired spaces preset with the list of desired content types which should be imported (eg "page", "blog" etc.). If variable will be empty or absent - default importable content types from current preset will be used.
3. Put csv files with content into $module . '/preset_assets/' . $preset_name . '/content/' . $content_type . '.csv'.  
4. Create new Vsite with selected preset.