### PR TITLE
Patches feeds_tamper for compatibility with PHP7

### DIFF
--- a/openscholar/drupal-org.make
+++ b/openscholar/drupal-org.make
@@ -121,6 +121,7 @@ projects[feeds][patch][] = "https://raw.githubusercontent.com/openscholar/opensc
 
 projects[feeds_tamper][subdir] = "contrib"
 projects[feeds_tamper][version] = 1.1
+projects[feeds_tamper][patch][] = "https://www.drupal.org/files/issues/feeds_tamper-fix-params-default-value-callback-2567431-2-7.x.patch"
 
 projects[feeds_xpathparser][subdir] = "contrib"
 projects[feeds_xpathparser][download][type] = git


### PR DESCRIPTION
Patch was referenced at https://www.drupal.org/node/2567431

It should be noted though that just upgrading the version of feeds_tamper
used (from 1.1 to 1.2) would also accomplish the same goal.

This would close #10323 and should also contribute to #10414 
