### PR TITLE
Issue #10418 — Fix zip theme upload error

### DIFF
--- a/openscholar/modules/cp/modules/cp_appearance/cp_appearance.module
+++ b/openscholar/modules/cp/modules/cp_appearance/cp_appearance.module
@@ -1059,7 +1059,7 @@ function cp_appearance_get_flavors() {
     $file_content = drupal_parse_info_file($info_file);
 
     $flavors[$name] = $file_content + array(
-      'path' => $info['path'],
+      'path' => dirname($info_file),
     );
   }
 

--- a/openscholar/modules/cp/modules/cp_appearance/includes/subtheme.inc
+++ b/openscholar/modules/cp/modules/cp_appearance/includes/subtheme.inc
@@ -7,7 +7,7 @@
  * How to use:
  *  $fid = 1;
  *  $file = new SubTheme($fid);
- *  $file->extract();
+ *  $file->extract(); // This isn't necessary anymore.
  *  $info = $file->parseInfo();
  *
  * or:
@@ -44,9 +44,16 @@ class SubTheme {
 
   /**
    * The path of the folder.
-   * @var
+   * @var string
    */
   public $path;
+
+  /**
+   * Path of the flavour file in the subthemes' folder (and it's ready to use).
+   *
+   * @var string|null
+   */
+  private $flavourPath;
 
   /**
    * Constructing the class.
@@ -56,6 +63,19 @@ class SubTheme {
    */
   public function __construct($fid = NULL) {
     $this->fid = $fid;
+    $this->flavourPath = NULL;
+    $this->fileInfo();
+
+    if (!empty(glob($this->extractPath . DIRECTORY_SEPARATOR . '*.flav'))) {
+      // Subtheme has a falvour file and
+      // is extracted already
+      // OR
+      // it's a git project, not a ZIP archive.
+      if (empty($this->path)) {
+        $this->path = $this->extractPath;
+      }
+      $this->flavourPath = reset(glob($this->extractPath . DIRECTORY_SEPARATOR . '*.flav'));
+    }
   }
 
   /**
@@ -70,33 +90,35 @@ class SubTheme {
       $streams[] = $stream . '://';
     }
 
+    $files_folder = variable_get('file_public_path', conf_path() . DIRECTORY_SEPARATOR . 'files');
+
     // Generate the folder name by the unique URI of the file.
     $file_name = str_replace($streams, '', $this->file->uri);
     $folder_name = str_replace(array('.', '_'), '-', $file_name);
 
-    $files_folder = variable_get('file_public_path', conf_path() . '/files');
-
-    $this->filePath = empty($this->filePath) ? $files_folder . '/' . $file_name : $this->filePath;
-    $this->extractPath = empty($this->extractPath) ? $files_folder . '/' . $folder_name : $this->extractPath;
+    $this->filePath = empty($this->filePath) ? $files_folder . DIRECTORY_SEPARATOR . $file_name : $this->filePath;
+    $this->extractPath = empty($this->extractPath) ? $files_folder . DIRECTORY_SEPARATOR . $folder_name : $this->extractPath;
   }
 
   /**
    * Extracting the zip file.
    */
   public function extract() {
-    $this->fileInfo();
+    if (!empty($this->flavourPath)) {
+      return;
+    }
 
     $zip = new ZipArchive;
-    $res = $zip->open($this->filePath);
 
-    if ($res === TRUE) {
+    if ($zip->open($this->filePath) === TRUE) {
       // Extract the file.
       $zip->extractTo($this->extractPath);
       $zip->close();
-      $this->path = $this->extractPath;
+
+      $this->processExtractedSubtheme(TRUE);
     }
     else {
-      // couldn't extract the zip file, display an error message and watchdog.
+      // Couldn't extract the zip file, display an error message and watchdog.
       $params = array(
         '@file' => $this->filePath,
         '@path' => $this->extractPath,
@@ -106,6 +128,135 @@ class SubTheme {
       watchdog('subtheme', $message);
       drupal_set_message($message, 'error');
     }
+  }
+
+  /**
+   * Helper callback to process the Subtheme.
+   *
+   * @param bool $cleanup_needed
+   *   Whether the subtheme folder has to be cleaned form unnecessary folders
+   *   or not.
+   */
+  private function processExtractedSubtheme($cleanup_needed = FALSE) {
+    $flav_root = $this->findFileByPattern($this->extractPath, '*.flav');
+    // We found a flavour file and can set up path for this subtheme.
+    $this->path = $this->extractPath;
+
+    if (
+      !$flav_root ||
+      $flav_root === $this->extractPath
+    ) {
+      return;
+    }
+
+    if ($cleanup_needed) {
+      //
+      // Remove unnecessary subfolders.
+      //
+      $dirs_in_path_root = glob($this->path . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR);
+      foreach ($dirs_in_path_root as $index => $dir_in_path_root) {
+        if (strpos($flav_root, $dir_in_path_root) !== 0) {
+          $this->deleteTree($dir_in_path_root);
+          unset($dirs_in_path_root[$index]);
+        }
+      }
+    }
+
+    //
+    // Move theme files and folders into the root path.
+    //
+    $flav_root_content = array_filter(scandir($flav_root), function($value) {
+      return !in_array($value, ['.', '..']);
+    });
+
+    foreach ($flav_root_content as $resource) {
+      rename(
+        $flav_root . DIRECTORY_SEPARATOR . $resource,
+        $this->path .  DIRECTORY_SEPARATOR . $resource
+      );
+    }
+
+    if ($cleanup_needed) {
+      // Remove the first subpath in the unzipped folder where the flavour files
+      // were extracted originally if it won't cause component loss.
+      // Exception example:
+      // Flavour file extracted to:
+      // @code
+      // public://
+      // |-- my-flavour-zip
+      //   |-- css
+      //     |-- my-flavout.flav
+      //     |-- screenshot.png
+      //     |-- css
+      //       |-- my-flavout.css
+      // @endcode
+      // In this case, we wont remove the 'public://my-flavour-zip/css' dir
+      // since it would lead to loose 'my-flavout.css' as well.
+      foreach ($dirs_in_path_root as $dir_in_path_root) {
+        if (!in_array(basename($dir_in_path_root), $flav_root_content)) {
+          $this->deleteTree($dir_in_path_root);
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper method to find file in a directory by a name pattern.
+   *
+   * @param string $path
+   *   The path to search in recursively.
+   * @param string $pattern
+   *   File or directory name pattern to match.
+   *
+   * @return string|null
+   *   Path to the matching resource found first or NULL if there are no matches
+   *   at all.
+   */
+  private function findFileByPattern($path, $pattern) {
+    $path_match = NULL;
+    $files_in_path = glob($path . DIRECTORY_SEPARATOR . trim($pattern, " \t\n\r\0\x0B" . DIRECTORY_SEPARATOR));
+
+    if (!empty($files_in_path)) {
+      return $path;
+    }
+
+    $dirs_in_path = glob($path . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR);
+
+    if (empty($dirs_in_path)) {
+      return NULL;
+    }
+
+    foreach ($dirs_in_path as $subdir) {
+      $path_match = $this->findFileByPattern($subdir, $pattern);
+
+      if ($path_match) {
+        break;
+      }
+    }
+
+    return $path_match;
+  }
+
+  /**
+   * Helper method to delete non-empty directory.
+   *
+   * @param string $dir
+   *   A relative or absolute dir to delete.
+   *
+   * @return bool
+   *   Returns TRUE on success or FALSE on failure (e.g. lack of permissions).
+   */
+  private function deleteTree($dir) {
+    $files = array_filter(scandir($dir), function($value) {
+      return !in_array($value, ['.', '..']);
+    });
+
+    foreach ($files as $file) {
+      $match = $dir . DIRECTORY_SEPARATOR . $file;
+      (is_dir($match)) ? $this->deleteTree($match) : unlink($match);
+    }
+
+    return rmdir($dir);
   }
 
   /**

--- a/openscholar/modules/frontend/os_common/os_common.info
+++ b/openscholar/modules/frontend/os_common/os_common.info
@@ -1,4 +1,3 @@
 name = OS Common JS Utilities
 description = Registers JS utilities that could be used by several interface components
 core = 7.x
-dependencies[] = vsite

--- a/openscholar/modules/frontend/os_common/os_common.info
+++ b/openscholar/modules/frontend/os_common/os_common.info
@@ -1,3 +1,4 @@
 name = OS Common JS Utilities
 description = Registers JS utilities that could be used by several interface components
 core = 7.x
+dependencies[] = vsite

--- a/openscholar/modules/frontend/os_common/os_common.module
+++ b/openscholar/modules/frontend/os_common/os_common.module
@@ -9,7 +9,7 @@ function os_common_library() {
   $path = drupal_get_path('module', 'os_common');
   $disable = array('alias' => TRUE);
   $rest = url('api', $disable);
-  $vsite = vsite_get_vsite();
+  $vsite = function_exists(vsite_get_vsite) ? vsite_get_vsite() : FALSE;
 
   $info['angularjs'] = array(
     'title' => 'AngularJS',

--- a/openscholar/modules/vsite/vsite.module
+++ b/openscholar/modules/vsite/vsite.module
@@ -761,7 +761,9 @@ function vsite_spaces_presets_alter(&$presets) {
   $pathauto_settings = _vsite_get_pathauto_settings();
   foreach ($presets as $name => &$preset) {
     if (in_array($name, variable_get('os_enabled_spaces_presets',array()))) {
-      $preset->value['variable'] = array_merge($pathauto_settings, $preset->value['variable']);
+      if (isset($preset->value) && is_array($preset->value['variable'])) {
+        $preset->value['variable'] = array_merge($pathauto_settings, $preset->value['variable']);
+      }
     }
   }
 }
@@ -2176,7 +2178,7 @@ function vsite_form_user_profile_form_alter(&$form, &$form_state, &$form_id){
     $form['field_first_name']['#prefix'] = '<a name="user_first_name" class="field_first_name_anchor">';
     $form['field_first_name']['#suffix'] = '</a>';
   }
-  
+
   if (module_exists('migrate_example')) {
     // To hide the Gender field from user_profile_form #10048
     unset($form['field_migrate_example_gender']);


### PR DESCRIPTION
This PR fixes #10418 .

The issue happened because the provided example zip file contains the flavour file (and it's additional resources) in a subfolder and not directly in root.

With this PR, the SubTheme class will search for an flavour file (`.flav`) recursively in the folder where the uploaded zip was extracted. If it founds a flavour file, then it will move every file to the zip extraction target folder.

Main modifications:
* Refactored constructor for SubTheme
* allow extraction only if the SubTheme hasn't the `.flav` file anywhere

New (private) methods:
* `processExtractedSubtheme`: called after that the zip file extracted.
  This method moves the flavour files to their _expected_ location and does a cleanup at the end of the process
* `findFileByPattern`: helper method for subtheme processing.
  Recursively searches for a file (by a defined pattern) in the given directory.
* `deleteTree`: helper method for subtheme processing, for removing non-empty folders.