### PR TITLE
Fix for Accordion widget iframe sizing bug

### DIFF
--- a/openscholar/modules/os/modules/os_boxes/misc/os_boxes.resize_parent.js
+++ b/openscholar/modules/os/modules/os_boxes/misc/os_boxes.resize_parent.js
@@ -24,6 +24,8 @@
     for (var i = 0; i < iframes.length; i++) {
       var delta = jQuery(iframes[i]).closest('.boxes-box').attr('id');
       if (
+        typeof Drupal !== 'undefined' &&
+        typeof Drupal.settings !== 'undefined' &&
         typeof Drupal.settings.widget_max_width != 'undefined' &&
         typeof Drupal.settings.widget_max_width[delta] != 'undefined' &&
         Drupal.settings.widget_max_width[delta] != '' &&
@@ -35,12 +37,11 @@
           jQuery(iframes[i]).attr("src", jQuery(iframes[i]).attr("src"));
           iframes[i].resized = true;
         }
-
       }
-      else if (typeof data.width != 'undefined') {
+      else if (typeof data.width != 'undefined' && data.width > 0) {
         iframes[i].width = data.width;
       }
-      if (typeof data.height != 'undefined') {
+      if (typeof data.height != 'undefined' && data.width > 0) {
         iframes[i].height = data.height;
       }
     }

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.css
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.css
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * Theme override for jQuery.ui.accordion.
+ *
+ * Using alternate method for hiding accordion content to fix iframe
+ * dimension/sizing issues.
+ */
+
+.accordion .ui-widget-content {
+  display: block !important;
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px,1px,1px,1px);
+  overflow: hidden;
+  height: 1px;
+}
+
+.accordion .ui-widget-content.ui-accordion-content-active {
+  position: static !important;
+  clip: auto;
+  height: auto;
+}

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.css
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.css
@@ -6,17 +6,14 @@
  * dimension/sizing issues.
  */
 
-.accordion .ui-widget-content {
+.accordion .ui-widget-content.os-boxes-accordion-loadfix {
+  box-sizing: border-box !important;
+  width: 100% !important;
   display: block !important;
   position: absolute !important;
   clip: rect(1px 1px 1px 1px);
   clip: rect(1px,1px,1px,1px);
   overflow: hidden;
   height: 1px;
-}
-
-.accordion .ui-widget-content.ui-accordion-content-active {
-  position: static !important;
-  clip: auto;
-  height: auto;
+  z-index: -1;
 }

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.inc
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.inc
@@ -31,6 +31,7 @@ class os_boxes_accordion extends os_boxes_widget_collection {
 
   function render() {
     $output = parent::render();
+    $accordion_plugin_path = drupal_get_path('module', 'os_boxes') . '/plugins/os_boxes_accordion';
 
     // Static variable to hold multiple accordion per page.
     $os_accordion_boxes = &drupal_static('os_accordion_boxes');
@@ -53,8 +54,9 @@ class os_boxes_accordion extends os_boxes_widget_collection {
           'library' => array(
             array('system', 'ui.accordion'),
           ),
+          'css' => array($accordion_plugin_path . '/os_boxes_accordion.css'),
           'js' => array(
-            drupal_get_path('module', 'os_boxes') . '/plugins/os_boxes_accordion/os_boxes_accordion.render.js',
+            $accordion_plugin_path . '/os_boxes_accordion.render.js',
             array(
               'type' => 'setting',
               'data' => array(

--- a/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.render.js
+++ b/openscholar/modules/os/modules/os_boxes/plugins/os_boxes_accordion/os_boxes_accordion.render.js
@@ -8,8 +8,15 @@
         $('#boxes-box-' + data.delta + ' > .boxes-box-content > .accordion', ctx).accordion({
           collapsible: true,
           heightStyle: 'content',
-          active: data.active
-        })
+          active: data.active,
+          beforeActivate: function( event, ui ) {
+            $(ui.newPanel).removeClass('os-boxes-accordion-loadfix');
+          }
+        }).children('.accordion-panel').each(function (index) {
+          if (data.active !== index) {
+            $(this).addClass('os-boxes-accordion-loadfix');
+          }
+        });
       });
     }
   }


### PR DESCRIPTION
Fixes #10459.

Issue was about that if the content of an iframe nested in an accordion widget was loaded __after__ jQuery.ui.accordion was initialized, then the accordion panel (which contains the iframe) was already hidden by an inline style `display: none` added by jQuery.ui.accordion. 

That made impossible to properly detect the dimensions of the iframe in `os_boxes.resize_parent.js`.

We're unable to control resource load order or properly detect when is an iframe fully loaded since most of the embeds are third party, and because of this, we cannot initalizi accordion after iframes are loaded. (Even if we would be able to do that, it would cause a much more noticeable FOUC on page load.)



The current solution hides initial accordion panels only visually (with the helper class `os-boxes-accordion-loadfix`) and contains some minor fixes for the resize parent module as well.