### PR TITLE
Resolves #10784: Notice: Undefined property: stdClass::$id in os_pages_translated_menu_link_alter()

### DIFF
--- a/openscholar/modules/os_features/os_pages/os_pages.module
+++ b/openscholar/modules/os_features/os_pages/os_pages.module
@@ -393,7 +393,7 @@ function os_pages_translated_menu_link_alter(&$link, $map) {
   // Non-site members can never see unpublished page.
   // User 1 should be able to though
   if ($vsite = vsite_get_vsite()) {
-    if ($GLOBALS['user']->uid != 1 && !og_is_member('node', $vsite->group->id)) {
+    if ($GLOBALS['user']->uid != 1 && !og_is_member('node', $vsite->group->nid)) {
       return;
     }
   }


### PR DESCRIPTION
Old code was checking the non-existent "id" property on the node object, when it should be checking "nid". I believe prior to my fix, all the code after the 'return' would never be executed... but now it will be. I think that means this bug has existed for 2 years, so I'm not sure if the code is even relevant anymore (since no one has reported anything broken?). It was originally written in #8691