### PR TITLE
Issue #10906: Fix failing monthly calendar test

### DIFF
--- a/.travis/RoboFile.php
+++ b/.travis/RoboFile.php
@@ -326,7 +326,10 @@ class RoboFile extends \Robo\Tasks
         $tasks[] = $this->taskExecStack()
             ->exec('docker-compose exec -T php ./vendor/bin/phpunit ' .
                 '-c web/core '.
-                '--debug \Drupal\Tests\os_fullcalendar\ExistingSite\EventMiniCalendarViewsTest /var/www/html/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php');
+                '--debug '.
+                ($groups ? '--group ' . $groups . ' ': ' ')  .
+                '--exclude-group=unit,functional,functional-javascript '.
+                '--verbose web/profiles/contrib/openscholar');
         return $tasks;
     }
 

--- a/.travis/RoboFile.php
+++ b/.travis/RoboFile.php
@@ -326,10 +326,7 @@ class RoboFile extends \Robo\Tasks
         $tasks[] = $this->taskExecStack()
             ->exec('docker-compose exec -T php ./vendor/bin/phpunit ' .
                 '-c web/core '.
-                '--debug '.
-                ($groups ? '--group ' . $groups . ' ': ' ')  .
-                '--exclude-group=unit,functional,functional-javascript '.
-                '--verbose web/profiles/contrib/openscholar');
+                '--debug \Drupal\Tests\os_fullcalendar\ExistingSite\EventMiniCalendarViewsTest /var/www/html/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php');
         return $tasks;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,8 @@
         },
         "patches": {
             "drupal/core": {
-                "Make sure TestSitePath exist before creating .htkey": "https://www.drupal.org/files/issues/2246725-24.patch"
+                "Make sure TestSitePath exist before creating .htkey": "https://www.drupal.org/files/issues/2246725-24.patch",
+                "Views Date Filter Datetime Granularity Option": "https://www.drupal.org/files/issues/2018-12-11/views_date_filter_granularity_2868014-60.patch"
             },
             "drupal/group_purl": {
                 "Prevent base path from interfering with purl detection": "https://www.drupal.org/files/issues/2019-01-17/group_purl.3026646-2.basepath.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1781433650ddac4c4863a107d8796a5",
+    "content-hash": "4ee370d8d68cea96b5c3144cf8f6d3ca",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3103,7 +3103,8 @@
                     "merge-extra": false
                 },
                 "patches_applied": {
-                    "Make sure TestSitePath exist before creating .htkey": "https://www.drupal.org/files/issues/2246725-24.patch"
+                    "Make sure TestSitePath exist before creating .htkey": "https://www.drupal.org/files/issues/2246725-24.patch",
+                    "Views Date Filter Datetime Granularity Option": "https://www.drupal.org/files/issues/2018-12-11/views_date_filter_granularity_2868014-60.patch"
                 }
             },
             "autoload": {

--- a/config/sync/views.view.calendar.yml
+++ b/config/sync/views.view.calendar.yml
@@ -395,7 +395,7 @@ display:
           value:
             min: ''
             max: ''
-            value: 'last day of this month 23:59:59'
+            value: 'last day of this month'
             type: offset
           group: 1
           exposed: false
@@ -426,6 +426,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          granularity: month
           plugin_id: datetime
         current_vsite_filter:
           id: current_vsite_filter
@@ -580,7 +581,7 @@ display:
           value:
             min: ''
             max: ''
-            value: 'now'
+            value: now
             type: offset
           group: 1
           exposed: false
@@ -611,6 +612,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          granularity: minute
           plugin_id: datetime
         current_vsite_filter:
           id: current_vsite_filter

--- a/config/sync/views.view.calendar.yml
+++ b/config/sync/views.view.calendar.yml
@@ -391,7 +391,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '<'
+          operator: '<='
           value:
             min: ''
             max: ''

--- a/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
+++ b/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
@@ -82,12 +82,6 @@ class EventMiniCalendarViewsTest extends EventTestBase {
     /** @var array $result */
     $result = views_get_view_result('calendar', 'block_2');
 
-    $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
-
-    foreach ($result as $item) {
-      $datetime = new DateTimePlus($item->_entity->field_recurring_date->first()->getValue()['value']);
-    }
-
     $this->assertCount(1, $result);
     /** @var \Drupal\views\ResultRow $item */
     foreach ($result as $item) {

--- a/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
+++ b/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
@@ -83,11 +83,9 @@ class EventMiniCalendarViewsTest extends EventTestBase {
     $result = views_get_view_result('calendar', 'block_2');
 
     $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
-    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
 
     foreach ($result as $item) {
       $datetime = new DateTimePlus($item->_entity->field_recurring_date->first()->getValue()['value']);
-      file_put_contents("public://{$item->_entity->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
     }
 
     $this->assertCount(1, $result);

--- a/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
+++ b/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\os_fullcalendar\ExistingSite;
 
 use Drupal\Component\Datetime\DateTimePlus;
-use Drupal\views\Views;
 
 /**
  * Tests mini calendar views.
@@ -35,35 +34,6 @@ class EventMiniCalendarViewsTest extends EventTestBase {
 
     /** @var array $result */
     $result = views_get_view_result('calendar', 'block_1');
-    $view = Views::getView('calendar');
-    $view->setDisplay('block_1');
-    $view->preExecute();
-    $view->execute();
-    file_put_contents('public://query.txt', $view->query->query());
-
-    $datetime = new DateTimePlus('now');
-    file_put_contents('public://now.txt', $datetime->format("Y-m-d\TH:i:s"));
-    file_put_contents('public://timezone.txt', $datetime->getTimezone());
-    file_put_contents('public://now-php.txt', $datetime->getPhpDateTime());
-    file_put_contents('public://offset.txt', $datetime->getOffset());
-    file_put_contents('public://errors.txt', print_r($datetime->getErrors(), TRUE));
-
-    $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
-    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
-
-    $datetime = new DateTimePlus($next_month_event->field_recurring_date->first()->getValue()['value']);
-    file_put_contents("public://{$next_month_event->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
-
-    $datetime = new DateTimePlus($this->event->field_recurring_date->first()->getValue()['value']);
-    file_put_contents("public://{$this->event->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
-
-    $connection = \Drupal::database();
-    $query = $connection->query("SELECT * from node_field_data");
-    file_put_contents("public://node_field_data.txt", print_r($query->fetchAll(), TRUE));
-    $query = $connection->query("SELECT * FROM group_content_field_data");
-    file_put_contents("public://group_content_field_data.txt", print_r($query->fetchAll(), TRUE));
-    $query = $connection->query("SELECT * FROM node__field_recurring_date");
-    file_put_contents("public://node__field_recurring_date.txt", print_r($query->fetchAll(), TRUE));
 
     // Next month event should not appear.
     $this->assertCount(1, $result);
@@ -111,6 +81,14 @@ class EventMiniCalendarViewsTest extends EventTestBase {
 
     /** @var array $result */
     $result = views_get_view_result('calendar', 'block_2');
+
+    $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
+    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
+
+    foreach ($result as $item) {
+      $datetime = new DateTimePlus($item->_entity->field_recurring_date->first()->getValue()['value']);
+      file_put_contents("public://{$item->_entity->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
+    }
 
     $this->assertCount(1, $result);
     /** @var \Drupal\views\ResultRow $item */

--- a/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
+++ b/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\os_fullcalendar\ExistingSite;
 
 use Drupal\Component\Datetime\DateTimePlus;
+use Drupal\views\Views;
 
 /**
  * Tests mini calendar views.
@@ -34,6 +35,35 @@ class EventMiniCalendarViewsTest extends EventTestBase {
 
     /** @var array $result */
     $result = views_get_view_result('calendar', 'block_1');
+    $view = Views::getView('calendar');
+    $view->setDisplay('block_1');
+    $view->preExecute();
+    $view->execute();
+    file_put_contents('public://query.txt', $view->query->query());
+
+    $datetime = new DateTimePlus('now');
+    file_put_contents('public://now.txt', $datetime->format("Y-m-d\TH:i:s"));
+    file_put_contents('public://timezone.txt', $datetime->getTimezone());
+    file_put_contents('public://now-php.txt', $datetime->getPhpDateTime());
+    file_put_contents('public://offset.txt', $datetime->getOffset());
+    file_put_contents('public://errors.txt', print_r($datetime->getErrors(), TRUE));
+
+    $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
+    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
+
+    $datetime = new DateTimePlus($next_month_event->field_recurring_date->first()->getValue()['value']);
+    file_put_contents("public://{$next_month_event->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
+
+    $datetime = new DateTimePlus($this->event->field_recurring_date->first()->getValue()['value']);
+    file_put_contents("public://{$this->event->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
+
+    $connection = \Drupal::database();
+    $query = $connection->query("SELECT * from node_field_data");
+    file_put_contents("public://node_field_data.txt", print_r($query->fetchAll(), TRUE));
+    $query = $connection->query("SELECT * FROM group_content_field_data");
+    file_put_contents("public://group_content_field_data.txt", print_r($query->fetchAll(), TRUE));
+    $query = $connection->query("SELECT * FROM node__field_recurring_date");
+    file_put_contents("public://node__field_recurring_date.txt", print_r($query->fetchAll(), TRUE));
 
     // Next month event should not appear.
     $this->assertCount(1, $result);
@@ -81,14 +111,6 @@ class EventMiniCalendarViewsTest extends EventTestBase {
 
     /** @var array $result */
     $result = views_get_view_result('calendar', 'block_2');
-
-    $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
-    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
-
-    foreach ($result as $item) {
-      $datetime = new DateTimePlus($item->_entity->field_recurring_date->first()->getValue()['value']);
-      file_put_contents("public://{$item->_entity->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
-    }
 
     $this->assertCount(1, $result);
     /** @var \Drupal\views\ResultRow $item */

--- a/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
+++ b/profile/modules/custom/os_fullcalendar/tests/src/ExistingSite/EventMiniCalendarViewsTest.php
@@ -83,9 +83,11 @@ class EventMiniCalendarViewsTest extends EventTestBase {
     $result = views_get_view_result('calendar', 'block_2');
 
     $datetime = new DateTimePlus('now', new \DateTimeZone('America/Anguilla'));
+    file_put_contents('public://now-anguilla.txt', $datetime->format("Y-m-d\TH:i:s"));
 
     foreach ($result as $item) {
       $datetime = new DateTimePlus($item->_entity->field_recurring_date->first()->getValue()['value']);
+      file_put_contents("public://{$item->_entity->label()}-utc.txt", $datetime->format("Y-m-d\TH:i:s"));
     }
 
     $this->assertCount(1, $result);


### PR DESCRIPTION
The test `Drupal\Tests\os_fullcalendar\ExistingSite\EventMiniCalendarViewsTest::testMonthlyCalendarView` is failing because the condition in views `2019-02-28T23:59:59 < 2019-03-01T00:00:00` fails to be `TRUE`. I think both the times are considered the same. Putting a date granularity setting fixes the problem.

---

In case of `composer.*` merge conflict, follow http://blog.doh.ms/2016/11/28/solving-conflicts-in-composer-lock/ to resolve `composer.*` conflicts, then do the following

```
composer update "drupal/core"
```

**Patches:**

```json
"drupal/core": {
    "Views Date Filter Datetime Granularity Option": "https://www.drupal.org/files/issues/2018-12-11/views_date_filter_granularity_2868014-60.patch"
}
```