### PR TITLE
Adding dependency on parent config to avoid config import error

### DIFF
--- a/config/sync/bibcite.bibcite_csl_style.national_library_of_medicine.yml
+++ b/config/sync/bibcite.bibcite_csl_style.national_library_of_medicine.yml
@@ -1,7 +1,9 @@
 uuid: f8e476b3-f08f-4ffb-abff-9ad8343f2b68
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - bibcite.bibcite_csl_style.vancouver
 id: national_library_of_medicine
 parent: vancouver
 label: 'National Library of Medicine'


### PR DESCRIPTION
#11790 
This is to fix config import error as one of the styles is dependent on other , adding dependency in config file manually as it is not done by the module automatically while cex