### PR TITLE
Publication View mode changes

### DIFF
--- a/config/sync/core.entity_form_display.bibcite_reference.artwork.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.artwork.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.audiovisual.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.audiovisual.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.bill.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.bill.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.book.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.book.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.book_chapter.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.book_chapter.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.broadcast.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.broadcast.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.case.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.case.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.chart.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.chart.default.yml
@@ -488,6 +488,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.classical.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.classical.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.conference_paper.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.conference_paper.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.conference_proceedings.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.conference_proceedings.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.database.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.database.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.film.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.film.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.government_report.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.government_report.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.hearing.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.hearing.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.journal.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.journal.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.journal_article.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.journal_article.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.legal_ruling.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.legal_ruling.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.magazine_article.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.magazine_article.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.manuscript.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.manuscript.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.map.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.map.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.miscellaneous.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.miscellaneous.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.miscellaneous_section.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.miscellaneous_section.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.newspaper_article.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.newspaper_article.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.patent.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.patent.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.personal.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.personal.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.presentation.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.presentation.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.report.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.report.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.software.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.software.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.statute.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.statute.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.thesis.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.thesis.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.unpublished.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.unpublished.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.web_article.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.web_article.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.web_project_page.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.web_project_page.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.web_service.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.web_service.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.bibcite_reference.website.default.yml
+++ b/config/sync/core.entity_form_display.bibcite_reference.website.default.yml
@@ -490,6 +490,14 @@ content:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
+  html_title:
+    type: text_textarea
+    weight: -10
+    settings:
+      rows: 1
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
   is_sticky:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_view_display.bibcite_reference.artwork.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.artwork.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.artwork.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.artwork.default.yml
@@ -478,5 +478,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.artwork.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.artwork.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.artwork.field_attach_files
     - field.field.bibcite_reference.artwork.field_extra_fields
     - field.field.bibcite_reference.artwork.field_publication_image
+    - field.field.bibcite_reference.artwork.field_redirect_to_source
     - field.field.bibcite_reference.artwork.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -17,7 +18,6 @@ dependencies:
       - bibcite_entity.bibcite_reference_type.artwork
   module:
     - image
-    - key_value_field
     - layout_builder
     - text
 third_party_settings:
@@ -33,47 +33,24 @@ bundle: artwork
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +114,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.audiovisual.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.audiovisual.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.audiovisual.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.audiovisual.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.audiovisual.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.audiovisual.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.audiovisual.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.audiovisual.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.audiovisual.field_attach_files
     - field.field.bibcite_reference.audiovisual.field_extra_fields
     - field.field.bibcite_reference.audiovisual.field_publication_image
+    - field.field.bibcite_reference.audiovisual.field_redirect_to_source
     - field.field.bibcite_reference.audiovisual.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -17,7 +18,6 @@ dependencies:
       - bibcite_entity.bibcite_reference_type.artwork
   module:
     - image
-    - key_value_field
     - layout_builder
     - text
 third_party_settings:
@@ -33,47 +33,24 @@ bundle: audiovisual
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +114,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.bill.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.bill.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.bill.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.bill.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.bill.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.bill.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.bill.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.bill.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.bill.field_attach_files
     - field.field.bibcite_reference.bill.field_extra_fields
     - field.field.bibcite_reference.bill.field_publication_image
+    - field.field.bibcite_reference.bill.field_redirect_to_source
     - field.field.bibcite_reference.bill.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: bill
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.book.field_attach_files
     - field.field.bibcite_reference.book.field_extra_fields
     - field.field.bibcite_reference.book.field_publication_image
+    - field.field.bibcite_reference.book.field_redirect_to_source
     - field.field.bibcite_reference.book.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: book
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,12 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true
+

--- a/config/sync/core.entity_view_display.bibcite_reference.book_chapter.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book_chapter.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book_chapter.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book_chapter.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book_chapter.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book_chapter.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.book_chapter.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.book_chapter.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.book_chapter.field_attach_files
     - field.field.bibcite_reference.book_chapter.field_extra_fields
     - field.field.bibcite_reference.book_chapter.field_publication_image
+    - field.field.bibcite_reference.book_chapter.field_redirect_to_source
     - field.field.bibcite_reference.book_chapter.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: book_chapter
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.broadcast.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.broadcast.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.broadcast.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.broadcast.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.broadcast.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.broadcast.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.broadcast.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.broadcast.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.broadcast.field_attach_files
     - field.field.bibcite_reference.broadcast.field_extra_fields
     - field.field.bibcite_reference.broadcast.field_publication_image
+    - field.field.bibcite_reference.broadcast.field_redirect_to_source
     - field.field.bibcite_reference.broadcast.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: broadcast
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.case.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.case.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.case.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.case.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.case.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.case.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.case.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.case.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.case.field_attach_files
     - field.field.bibcite_reference.case.field_extra_fields
     - field.field.bibcite_reference.case.field_publication_image
+    - field.field.bibcite_reference.case.field_redirect_to_source
     - field.field.bibcite_reference.case.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: case
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.chart.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.chart.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.chart.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.chart.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.chart.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.chart.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.chart.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.chart.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.chart.field_attach_files
     - field.field.bibcite_reference.chart.field_extra_fields
     - field.field.bibcite_reference.chart.field_publication_image
+    - field.field.bibcite_reference.chart.field_redirect_to_source
     - field.field.bibcite_reference.chart.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: chart
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.classical.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.classical.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.classical.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.classical.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.classical.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.classical.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.classical.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.classical.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.classical.field_attach_files
     - field.field.bibcite_reference.classical.field_extra_fields
     - field.field.bibcite_reference.classical.field_publication_image
+    - field.field.bibcite_reference.classical.field_redirect_to_source
     - field.field.bibcite_reference.classical.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: classical
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_paper.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_paper.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_paper.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_paper.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_paper.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_paper.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_paper.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_paper.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.conference_paper.field_attach_files
     - field.field.bibcite_reference.conference_paper.field_extra_fields
     - field.field.bibcite_reference.conference_paper.field_publication_image
+    - field.field.bibcite_reference.conference_paper.field_redirect_to_source
     - field.field.bibcite_reference.conference_paper.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: conference_paper
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.conference_proceedings.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.conference_proceedings.field_attach_files
     - field.field.bibcite_reference.conference_proceedings.field_extra_fields
     - field.field.bibcite_reference.conference_proceedings.field_publication_image
+    - field.field.bibcite_reference.conference_proceedings.field_redirect_to_source
     - field.field.bibcite_reference.conference_proceedings.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: conference_proceedings
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.database.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.database.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.database.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.database.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.database.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.database.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.database.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.database.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.database.field_attach_files
     - field.field.bibcite_reference.database.field_extra_fields
     - field.field.bibcite_reference.database.field_publication_image
+    - field.field.bibcite_reference.database.field_redirect_to_source
     - field.field.bibcite_reference.database.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: database
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.film.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.film.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.film.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.film.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.film.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.film.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.film.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.film.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.film.field_attach_files
     - field.field.bibcite_reference.film.field_extra_fields
     - field.field.bibcite_reference.film.field_publication_image
+    - field.field.bibcite_reference.film.field_redirect_to_source
     - field.field.bibcite_reference.film.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: film
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.government_report.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.government_report.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.government_report.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.government_report.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.government_report.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.government_report.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.government_report.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.government_report.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.government_report.field_attach_files
     - field.field.bibcite_reference.government_report.field_extra_fields
     - field.field.bibcite_reference.government_report.field_publication_image
+    - field.field.bibcite_reference.government_report.field_redirect_to_source
     - field.field.bibcite_reference.government_report.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: government_report
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.hearing.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.hearing.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.hearing.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.hearing.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.hearing.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.hearing.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.hearing.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.hearing.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.hearing.field_attach_files
     - field.field.bibcite_reference.hearing.field_extra_fields
     - field.field.bibcite_reference.hearing.field_publication_image
+    - field.field.bibcite_reference.hearing.field_redirect_to_source
     - field.field.bibcite_reference.hearing.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: hearing
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.journal.field_attach_files
     - field.field.bibcite_reference.journal.field_extra_fields
     - field.field.bibcite_reference.journal.field_publication_image
+    - field.field.bibcite_reference.journal.field_redirect_to_source
     - field.field.bibcite_reference.journal.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: journal
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal_article.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal_article.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal_article.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal_article.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal_article.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal_article.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.journal_article.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.journal_article.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.journal_article.field_attach_files
     - field.field.bibcite_reference.journal_article.field_extra_fields
     - field.field.bibcite_reference.journal_article.field_publication_image
+    - field.field.bibcite_reference.journal_article.field_redirect_to_source
     - field.field.bibcite_reference.journal_article.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: journal_article
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.legal_ruling.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.legal_ruling.field_attach_files
     - field.field.bibcite_reference.legal_ruling.field_extra_fields
     - field.field.bibcite_reference.legal_ruling.field_publication_image
+    - field.field.bibcite_reference.legal_ruling.field_redirect_to_source
     - field.field.bibcite_reference.legal_ruling.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: legal_ruling
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.magazine_article.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.magazine_article.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.magazine_article.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.magazine_article.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.magazine_article.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.magazine_article.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.magazine_article.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.magazine_article.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.magazine_article.field_attach_files
     - field.field.bibcite_reference.magazine_article.field_extra_fields
     - field.field.bibcite_reference.magazine_article.field_publication_image
+    - field.field.bibcite_reference.magazine_article.field_redirect_to_source
     - field.field.bibcite_reference.magazine_article.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: magazine_article
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.manuscript.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.manuscript.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.manuscript.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.manuscript.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.manuscript.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.manuscript.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.manuscript.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.manuscript.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.manuscript.field_attach_files
     - field.field.bibcite_reference.manuscript.field_extra_fields
     - field.field.bibcite_reference.manuscript.field_publication_image
+    - field.field.bibcite_reference.manuscript.field_redirect_to_source
     - field.field.bibcite_reference.manuscript.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: manuscript
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.map.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.map.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.map.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.map.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.map.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.map.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.map.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.map.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.map.field_attach_files
     - field.field.bibcite_reference.map.field_extra_fields
     - field.field.bibcite_reference.map.field_publication_image
+    - field.field.bibcite_reference.map.field_redirect_to_source
     - field.field.bibcite_reference.map.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: map
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.miscellaneous.field_attach_files
     - field.field.bibcite_reference.miscellaneous.field_extra_fields
     - field.field.bibcite_reference.miscellaneous.field_publication_image
+    - field.field.bibcite_reference.miscellaneous.field_redirect_to_source
     - field.field.bibcite_reference.miscellaneous.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: miscellaneous
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.miscellaneous_section.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.miscellaneous_section.field_attach_files
     - field.field.bibcite_reference.miscellaneous_section.field_extra_fields
     - field.field.bibcite_reference.miscellaneous_section.field_publication_image
+    - field.field.bibcite_reference.miscellaneous_section.field_redirect_to_source
     - field.field.bibcite_reference.miscellaneous_section.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: miscellaneous_section
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.newspaper_article.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.newspaper_article.field_attach_files
     - field.field.bibcite_reference.newspaper_article.field_extra_fields
     - field.field.bibcite_reference.newspaper_article.field_publication_image
+    - field.field.bibcite_reference.newspaper_article.field_redirect_to_source
     - field.field.bibcite_reference.newspaper_article.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: newspaper_article
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.patent.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.patent.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.patent.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.patent.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.patent.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.patent.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.patent.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.patent.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.patent.field_attach_files
     - field.field.bibcite_reference.patent.field_extra_fields
     - field.field.bibcite_reference.patent.field_publication_image
+    - field.field.bibcite_reference.patent.field_redirect_to_source
     - field.field.bibcite_reference.patent.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: patent
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.personal.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.personal.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.personal.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.personal.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.personal.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.personal.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.personal.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.personal.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.personal.field_attach_files
     - field.field.bibcite_reference.personal.field_extra_fields
     - field.field.bibcite_reference.personal.field_publication_image
+    - field.field.bibcite_reference.personal.field_redirect_to_source
     - field.field.bibcite_reference.personal.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: personal
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.presentation.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.presentation.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.presentation.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.presentation.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.presentation.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.presentation.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.presentation.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.presentation.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.presentation.field_attach_files
     - field.field.bibcite_reference.presentation.field_extra_fields
     - field.field.bibcite_reference.presentation.field_publication_image
+    - field.field.bibcite_reference.presentation.field_redirect_to_source
     - field.field.bibcite_reference.presentation.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: presentation
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.report.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.report.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.report.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.report.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.report.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.report.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.report.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.report.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.report.field_attach_files
     - field.field.bibcite_reference.report.field_extra_fields
     - field.field.bibcite_reference.report.field_publication_image
+    - field.field.bibcite_reference.report.field_redirect_to_source
     - field.field.bibcite_reference.report.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: report
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.software.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.software.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.software.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.software.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.software.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.software.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.software.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.software.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.software.field_attach_files
     - field.field.bibcite_reference.software.field_extra_fields
     - field.field.bibcite_reference.software.field_publication_image
+    - field.field.bibcite_reference.software.field_redirect_to_source
     - field.field.bibcite_reference.software.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: software
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.statute.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.statute.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.statute.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.statute.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.statute.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.statute.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.statute.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.statute.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.statute.field_attach_files
     - field.field.bibcite_reference.statute.field_extra_fields
     - field.field.bibcite_reference.statute.field_publication_image
+    - field.field.bibcite_reference.statute.field_redirect_to_source
     - field.field.bibcite_reference.statute.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: statute
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.thesis.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.thesis.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.thesis.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.thesis.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.thesis.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.thesis.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.thesis.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.thesis.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.thesis.field_attach_files
     - field.field.bibcite_reference.thesis.field_extra_fields
     - field.field.bibcite_reference.thesis.field_publication_image
+    - field.field.bibcite_reference.thesis.field_redirect_to_source
     - field.field.bibcite_reference.thesis.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: thesis
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.unpublished.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.unpublished.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.unpublished.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.unpublished.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.unpublished.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.unpublished.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.unpublished.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.unpublished.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.unpublished.field_attach_files
     - field.field.bibcite_reference.unpublished.field_extra_fields
     - field.field.bibcite_reference.unpublished.field_publication_image
+    - field.field.bibcite_reference.unpublished.field_redirect_to_source
     - field.field.bibcite_reference.unpublished.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: unpublished
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_article.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_article.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_article.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_article.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_article.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_article.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_article.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_article.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.web_article.field_attach_files
     - field.field.bibcite_reference.web_article.field_extra_fields
     - field.field.bibcite_reference.web_article.field_publication_image
+    - field.field.bibcite_reference.web_article.field_redirect_to_source
     - field.field.bibcite_reference.web_article.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: web_article
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_project_page.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_project_page.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_project_page.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_project_page.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_project_page.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_project_page.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_project_page.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_project_page.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.web_project_page.field_attach_files
     - field.field.bibcite_reference.web_project_page.field_extra_fields
     - field.field.bibcite_reference.web_project_page.field_publication_image
+    - field.field.bibcite_reference.web_project_page.field_redirect_to_source
     - field.field.bibcite_reference.web_project_page.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: web_project_page
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_service.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_service.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_service.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_service.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_service.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_service.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.web_service.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.web_service.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.web_service.field_attach_files
     - field.field.bibcite_reference.web_service.field_extra_fields
     - field.field.bibcite_reference.web_service.field_publication_image
+    - field.field.bibcite_reference.web_service.field_redirect_to_source
     - field.field.bibcite_reference.web_service.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: web_service
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.website.citation.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.website.citation.yml
@@ -127,6 +127,8 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_redirect_to_source: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.website.default.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.website.default.yml
@@ -465,5 +465,7 @@ content:
 hidden:
   bibcite_type: true
   citation: true
+  field_redirect_to_source: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.website.table.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.website.table.yml
@@ -434,6 +434,8 @@ hidden:
   field_attach_files: true
   field_extra_fields: true
   field_publication_image: true
+  field_redirect_to_source: true
   field_taxonomy_terms: true
+  html_title: true
   langcode: true
   uid: true

--- a/config/sync/core.entity_view_display.bibcite_reference.website.teaser.yml
+++ b/config/sync/core.entity_view_display.bibcite_reference.website.teaser.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.bibcite_reference.website.field_attach_files
     - field.field.bibcite_reference.website.field_extra_fields
     - field.field.bibcite_reference.website.field_publication_image
+    - field.field.bibcite_reference.website.field_redirect_to_source
     - field.field.bibcite_reference.website.field_taxonomy_terms
-    - image.style.publication_details_image
+    - image.style.publication_details_view
   enforced:
     module:
       - bibcite_entity
@@ -33,47 +34,24 @@ bundle: website
 mode: teaser
 content:
   citation:
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_extra_fields:
-    type: key_value
-    weight: 5
-    region: content
-    label: hidden
-    settings:
-      value_only: false
-    third_party_settings: {  }
   field_publication_image:
-    weight: 2
+    weight: 0
     label: hidden
     settings:
-      image_style: publication_details_image
+      image_style: publication_details_view
       image_link: ''
     third_party_settings: {  }
     type: image
     region: content
-  field_taxonomy_terms:
-    weight: 1
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  full_text:
-    type: text_default
-    weight: 3
-    region: content
-    label: above
-    settings: {  }
-    third_party_settings: {  }
   notes:
     type: text_default
-    weight: 4
+    weight: 2
     region: content
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
   publication_image:
@@ -137,6 +115,11 @@ hidden:
   bibcite_volume: true
   bibcite_year: true
   field_attach_files: true
+  field_extra_fields: true
+  field_redirect_to_source: true
+  field_taxonomy_terms: true
+  full_text: true
+  html_title: true
   keywords: true
   langcode: true
   uid: true

--- a/config/sync/image.style.publication_details_view.yml
+++ b/config/sync/image.style.publication_details_view.yml
@@ -1,0 +1,15 @@
+uuid: 9428b9aa-21cc-435e-be31-d5b0cf2a51a6
+langcode: en
+status: true
+dependencies: {  }
+name: publication_details_view
+label: 'Publication Details View'
+effects:
+  2087f3c5-f3b5-4d38-bf8a-660aad92e28e:
+    uuid: 2087f3c5-f3b5-4d38-bf8a-660aad92e28e
+    id: image_scale
+    weight: 1
+    data:
+      width: 50
+      height: 65
+      upscale: false

--- a/profile/modules/cp/modules/cp_taxonomy/tests/src/ExistingSiteJavascript/CpTaxonomyCacheTest.php
+++ b/profile/modules/cp/modules/cp_taxonomy/tests/src/ExistingSiteJavascript/CpTaxonomyCacheTest.php
@@ -115,30 +115,6 @@ class CpTaxonomyCacheTest extends CpTaxonomyExistingSiteJavascriptTestBase {
   }
 
   /**
-   * Test publication listing caching.
-   */
-  public function testPublicationListingCaching() {
-    $web_assert = $this->assertSession();
-    $publication = $this->createReference([
-      'field_taxonomy_terms' => [
-        $this->term->id(),
-      ],
-    ]);
-    $this->group->addContent($publication, 'group_entity:bibcite_reference');
-
-    // Test listing.
-    $this->showTermsOnListing(['bibcite_reference:*']);
-    $this->visitViaVsite("publications", $this->group);
-    $web_assert->statusCodeEquals(200);
-    $web_assert->pageTextContains($this->term->label());
-    Cache::invalidateTags(['entity-with-taxonomy-terms:' . $this->group->id()]);
-    $this->hideTermsOnListing();
-    $this->visitViaVsite("publications", $this->group);
-    $web_assert->statusCodeEquals(200);
-    $web_assert->pageTextNotContains($this->term->label());
-  }
-
-  /**
    * Set config, show terms on entity pages.
    */
   private function showTermsOnPage() {


### PR DESCRIPTION
https://github.com/openscholar/openscholar/issues/11720#issuecomment-510545216

This also adds some mismatched configs, which somehow might have got deleted for html_title and other fields.
Also removing a test which checked taxonomy tags on publications listing page as I have removed tags field from teaser view of publications.