### PR TITLE
fixing missspelt component keyword to fix site error.

### DIFF
--- a/profile/modules/os/os.libraries.yml
+++ b/profile/modules/os/os.libraries.yml
@@ -136,7 +136,7 @@ fileHandler:
   js:
     js/FileHandler/FileHandler.module.js: { }
   css:
-    componenet:
+    component:
       js/FileHandler/fileUploadHandler.css: { }
   paths: js/FileHandler
   drupalSettings:


### PR DESCRIPTION
![Screenshot 2019-07-18 at 9 31 03 AM](https://user-images.githubusercontent.com/38376852/61428335-583df500-a93f-11e9-9244-bf2e137e57f3.png)
Getting the error as shown in Screenshot after the latest pull, corrected the error in this PR