### PR TITLE
Simplify reverse proxy part of local setup by making traefik a service within docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ composer require drupal/devel:~1.0
 After that:
 
 ```bash
-
-git clone https://github.com/jaybeaton/traefik-helper.git traefik-helper
-cd traefik-helper
-./traefik-helper.sh up -d
-cd ..
 git clone --branch 8.x-1.x-dev https://github.com/openscholar/openscholar.git some-dir
 cd some-dir
 cp defaults/.env .
@@ -58,15 +53,3 @@ make
 ```
 
 Access your development setup from http://home.d8.theopenscholar.com
-
-## Note:
-As the Docker image traefik has a new release, if you have downloaded the latest traefik-helper, then it needs modification.
-In traefik-helper.yml file (path: `/tmp/traefik-helper.yml`), if you find image is using latest traefik version like shown below:
-```
-version: '2'
-
-services:
-  traefik:
-    image: traefik
-```
-modify it to use the 1.7 verson as `image: traefik:1.7` to fix Docker errors.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,14 @@ services:
     ports:
       - "9222:9222"
 
+  traefik:
+    image: traefik:1.7
+    command: -c /dev/null --web --docker --logLevel=INFO
+    ports:
+      - '${WEB_PORT-80}:80'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   node:
     image: mhart/alpine-node:11
     container_name: "${PROJECT_NAME}_drupal_nodejs"


### PR DESCRIPTION
### Disclaimer 😝 🙃 

This is my first PR, so please forgive wrong branch names or any CI/CD process that breaks.

### Problem

A local setup hiccup (related to `traefik`) was preventing the local d8 site from opening in the browser.

### Proposed Solution

Adding specific version of `traefik` (that works for us) as a connected service inside our `docker-compose.yml`. Doing so makes reverse proxy setup as seamless as our rest of php, mariadb, etc, and works out of the box with just `docker-compose up -d`

### Other Things Tried

Everything worked on following the local setup instructions, but the site would not open in the browser. I was seeing the below error.
```
This site can’t be reached home.d8.theopenscholar.com refused to connect.
Search Google for home openscholar
ERR_CONNECTION_REFUSED
```

I ensured I was following the instructions to use `traefik:1.7` for reverse proxy as noted in the README https://github.com/openscholar/openscholar/blob/4505c816e976986ecb76927c5f9202cee84b5ec3/README.md
... but still the same error.

I found something on the internets about configuring mac to bypass proxy settings for local sites, and tried that, but that did not work either.
![local-proxy-settings](https://user-images.githubusercontent.com/140441/68159674-3a14f880-ff20-11e9-85df-82e1169629f5.png)

Tried spinning up traefik again but error-ed out
```
 ./traefik-helper.sh up -d
Networks found:
---------------
openscholar_default

Starting traefikhelper_traefik_1 ... error

ERROR: for traefikhelper_traefik_1  Cannot start service traefik: b'network 2928c693e27345b292e129fd0e736fbe9c6072c963da69e0118c7469353230dd not found'

ERROR: for traefik  Cannot start service traefik: b'network 2928c693e27345b292e129fd0e736fbe9c6072c963da69e0118c7469353230dd not found'
ERROR: Encountered errors while bringing up the project.
```
